### PR TITLE
Refactor: `sqlt_cpt_post_title` to `sqlt_cpt_post_values`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Refactor filter: `sqlt_cpt_post_title` to `sqlt_cpt_post_values`.
+
 ## 1.1.0
 * Fix missing `Import` route class.
 * Implement `Post` class for handling CPTs.

--- a/README.md
+++ b/README.md
@@ -79,25 +79,30 @@ public function custom_rows( $rows ): array {
 - rows _`{string[]}`_ By default this will be a string array of row values parsed from the table that is being imported.
 <br/>
 
-#### `sqlt_cpt_post_title`
+#### `sqlt_cpt_post_values`
 
-This custom hook provides a way to filter the post title values being inserted into the post during import.
+This custom hook provides a way to filter the WP post values before import. An e.g is shown below where the `post_title` is filtered to use the `first_name` and `last_name` of the imported `worker` data.
 
 ```php
-add_action( 'sqlt_cpt_post_title', [ $this, 'custom_title' ], 10, 3 );
+add_filter( 'sqlt_cpt_post_values', [ $this, 'filter_post_title' ], 10, 2 );
 
-public function custom_title( $post_title, $table_row, $table_columns ): array {
-    $key = array_search( 'first_name', $table_columns );
+public function filter_post_title( $args, $post_import ): array {
+    if ( 'worker' === $args['post_type'] ?? '' ) {
+        $args['post_title'] = sprintf(
+            '%s %s',
+            $post_import['first_name'] ?? '',
+            $post_import['last_name'] ?? ''
+        );
+    }
 
-    return sanitize_text_field( $table_row[ $key ] );
+    return $args;
 }
 ```
 
 **Parameters**
 
-- post_title _`string`_ By default this will be a string from the first column of the table row that is being parsed.
-- table_row _`{mixed[]}`_ By default this will be a string array of row values parsed from the table that is being imported.
-- table_columns _`{string[]}`_ By default this will be a string array of column names parsed from the table that is being imported.
+- args _`{mixed[]}`_ By default this will be an associative array containg the familiar WP Post values (`post_type`, `post_title`, `meta_input` & `post_status`) to be inserted.
+- post_import _`{mixed[]}`_ By default this will be an associative array containg the key, value pair of the imported data.
 <br/>
 
 #### `sqlt_cpt_post_labels`

--- a/tests/php/Routes/ImportTest.php
+++ b/tests/php/Routes/ImportTest.php
@@ -222,26 +222,6 @@ class ImportTest extends TestCase {
 				}
 			);
 
-		\WP_Mock::expectFilter(
-			'sqlt_cpt_post_title',
-			'John Doe',
-			[
-				1,
-				'John Doe',
-				37,
-				'M',
-				'john@doe.com',
-			],
-			[
-				'id',
-				'name',
-				'age',
-				'sex',
-				'email_address',
-				'date_created',
-			]
-		);
-
 		$response = $import->get_response();
 
 		$this->assertSame( null, $response );
@@ -275,24 +255,28 @@ class ImportTest extends TestCase {
 		];
 
 		\WP_Mock::expectFilter(
-			'sqlt_cpt_post_title',
-			'John Doe',
+			'sqlt_cpt_post_values',
 			[
-				1,
-				'John Doe',
-				37,
-				'M',
-				'john@doe.com',
-				'00:00:00',
+				'post_type'   => 'student',
+				'post_title'  => 'John Doe',
+				'meta_input'  => [
+					'id'            => 1,
+					'name'          => 'John Doe',
+					'age'           => 37,
+					'sex'           => 'M',
+					'email_address' => 'john@doe.com',
+					'date_created'  => '00:00:00',
+				],
+				'post_status' => 'publish',
 			],
 			[
-				'id',
-				'name',
-				'age',
-				'sex',
-				'email_address',
-				'date_created',
-			]
+				'id'            => 1,
+				'name'          => 'John Doe',
+				'age'           => 37,
+				'sex'           => 'M',
+				'email_address' => 'john@doe.com',
+				'date_created'  => '00:00:00',
+			],
 		);
 
 		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
@@ -344,24 +328,28 @@ class ImportTest extends TestCase {
 		];
 
 		\WP_Mock::expectFilter(
-			'sqlt_cpt_post_title',
-			'John Doe',
+			'sqlt_cpt_post_values',
 			[
-				1,
-				'John Doe',
-				37,
-				'M',
-				'john@doe.com',
-				'00:00:00',
+				'post_type'   => 'student',
+				'post_title'  => 'John Doe',
+				'meta_input'  => [
+					'id'            => 1,
+					'name'          => 'John Doe',
+					'age'           => 37,
+					'sex'           => 'M',
+					'email_address' => 'john@doe.com',
+					'date_created'  => '00:00:00',
+				],
+				'post_status' => 'publish',
 			],
 			[
-				'id',
-				'name',
-				'age',
-				'sex',
-				'email_address',
-				'date_created',
-			]
+				'id'            => 1,
+				'name'          => 'John Doe',
+				'age'           => 37,
+				'sex'           => 'M',
+				'email_address' => 'john@doe.com',
+				'date_created'  => '00:00:00',
+			],
 		);
 
 		\WP_Mock::userFunction( 'wp_insert_post' )


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/1).

## Description / Background Context

At the moment we are currently using the `sqlt_cpt_post_title` filter to modify ONLY the **post title** of the imported data before it is being inserted into a new WP Post. Noticeably, there is currently no way for users to modify other aspects of the post array before it is inserted.

This PR eliminates this filter in favour of a new `sqlt_cpt_post_values` filter that accepts the conventional WP post $args array. This gives users more flexibility to add information to the post array before insertion.

## Testing Instructions

1. Pull PR to local.
2. In the `functions.php` of your theme, implement a custom filter to use the `first_name` and `last_name` keys of the imported data like so:

```php
add_filter( 'sqlt_cpt_post_values', 'filter_post_title', 10, 2 );

function filter_post_title( $args, $table_row ): array {
    if ( 'worker' === $args['post_type'] ?? '' ) {
        $args['post_title'] = sprintf(
            '%s %s',
            $table_row['first_name'] ?? '',
            $table_row['last_name'] ?? ''
        );
    }

    return $args;
}
```
3. Create an SQL file called `workers.sql`, add the following string into and save:

```sql
-- phpMyAdmin SQL Dump
-- version 5.2.1
-- https://www.phpmyadmin.net/
--
-- Host: mysql
-- Generation Time: Jan 10, 2025 at 04:51 PM
-- Server version: 8.4.0
-- PHP Version: 8.2.20

SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
START TRANSACTION;
SET time_zone = "+00:00";

CREATE TABLE `worker` (
  `id` int NOT NULL,
  `first_name` varchar(50) NOT NULL,
  `last_name` varchar(50) NOT NULL,
  `age` int DEFAULT NULL,
  `sex` char(1) DEFAULT NULL,
  `email_address` varchar(100) NOT NULL
) ;

--
-- Dumping data for table `worker`
--

INSERT INTO `worker` (`id`, `first_name`, `last_name`, `age`, `sex`, `email_address`) VALUES
(1, 'John', 'Doe', 30, 'M', 'john.doe@example.com'),
(2, 'Jane', 'Smith', 28, 'F', 'jane.smith@example.com'),
(3, 'Michael', 'Brown', 35, 'M', 'michael.brown@example.com'),
(4, 'Emily', 'Davis', 26, 'F', 'emily.davis@example.com'),
(5, 'David', 'Wilson', 40, 'M', 'david.wilson@example.com');

```
4. Import the SQL file, you should now see the new filter works correctly and assigns the `first_name` and `last_name` to the `post_title` like so:

<img width="487" alt="Screenshot 2025-01-10 at 18 07 33" src="https://github.com/user-attachments/assets/72da48e0-4763-4511-ba0a-103e26ae12f4" />

---

<img width="1450" alt="Screenshot 2025-01-10 at 18 11 24" src="https://github.com/user-attachments/assets/1e235936-1357-4b25-bd06-a9896c7d7fc7" />

<img width="1449" alt="Screenshot 2025-01-10 at 18 12 21" src="https://github.com/user-attachments/assets/1159f162-7f60-4d22-81a2-0403ee3c577f" />
