### PR TITLE
Chore: Write jest Unit tests for components

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -13,7 +13,7 @@ const ProgressBar = ({ isLoading, progress }): JSX.Element => {
     <>
       {
         isLoading && (
-          <div className="sqlt-cpt-progress-bar">
+          <div className="sqlt-cpt-progress-bar" role="progressbar">
             <div>
               <div style={{ width: `${progress}%` }} />
             </div>

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -24,7 +24,7 @@ const TableColumns = ({ parsedSQL }): JSX.Element => {
                 return (
                   <Disabled key={ index } name={ name } />
                 )
-              })
+              } )
             }
           </div>
         )

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -17,7 +17,7 @@ const TableColumns = ({ parsedSQL }): JSX.Element => {
     <>
       {
         parsedSQL.tableColumns.length > 0 && (
-          <div className="sqlt-cpt-table-columns">
+          <div className="sqlt-cpt-table-columns" role="list">
             <h3>{ __( 'Columns', 'sql-to-cpt' ) }</h3>
             {
               parsedSQL.tableColumns.map((name: string) => {

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -20,9 +20,9 @@ const TableColumns = ({ parsedSQL }): JSX.Element => {
           <div className="sqlt-cpt-table-columns" role="list">
             <h3>{ __( 'Columns', 'sql-to-cpt' ) }</h3>
             {
-              parsedSQL.tableColumns.map((name: string) => {
+              parsedSQL.tableColumns.map( ( name: string, index: number ) => {
                 return (
-                  <Disabled name={ name } />
+                  <Disabled key={ index } name={ name } />
                 )
               })
             }

--- a/src/components/TableName.tsx
+++ b/src/components/TableName.tsx
@@ -17,7 +17,7 @@ const TableName = ({ parsedSQL }): JSX.Element => {
     <>
       {
         parsedSQL.tableName && (
-          <div className="sqlt-cpt-table-name">
+          <div className="sqlt-cpt-table-name" role="list">
             <h3>{ __( 'Table', 'sql-to-cpt' ) }</h3>
             <Disabled
               name={ parsedSQL.tableName }

--- a/tests/js/Disabled.test.tsx
+++ b/tests/js/Disabled.test.tsx
@@ -17,5 +17,7 @@ describe( 'Disabled', () => {
     const input = screen.getByRole( 'textbox' );
     expect( input ).toBeDisabled();
     expect( input ).toHaveValue( 'post_title' );
+    expect( input ).toBeInTheDocument();
+    expect( input ).toBeInstanceOf( HTMLInputElement );
   } );
 } );

--- a/tests/js/Disabled.test.tsx
+++ b/tests/js/Disabled.test.tsx
@@ -13,7 +13,7 @@ describe( 'Disabled', () => {
       `<p><input type="text" disabled="" value="post_title"></p>`
     );
 
-    // Assert the input is rendered and is disabled
+    // Assert the input is rendered and is disabled.
     const input = screen.getByRole( 'textbox' );
     expect( input ).toBeDisabled();
     expect( input ).toHaveValue( 'post_title' );

--- a/tests/js/ImportButton.test.tsx
+++ b/tests/js/ImportButton.test.tsx
@@ -52,6 +52,8 @@ describe( 'ImportButton', () => {
     // Assert the button is displayed.
     const uploadButton = screen.getByRole( 'button' );
     expect( uploadButton ).toHaveClass( 'primary' );
+    expect( uploadButton ).toBeInTheDocument();
+    expect( uploadButton ).toBeInstanceOf( HTMLButtonElement );
   } );
 
 
@@ -85,6 +87,8 @@ describe( 'ImportButton', () => {
 
     // Test expectations.
     expect( uploadButton ).toHaveClass( 'primary' );
+    expect( uploadButton ).toBeInTheDocument();
+    expect( uploadButton ).toBeInstanceOf( HTMLButtonElement );
     expect( consoleSpy ).toHaveBeenCalled();
     expect( consoleSpy ).toHaveBeenCalledWith( 'Handle upload fired!' );
     expect( consoleSpy ).toHaveBeenCalledTimes( 1 );
@@ -125,6 +129,8 @@ describe( 'ImportButton', () => {
     // Assert the button is displayed.
     const importButton = screen.getByRole( 'button' );
     expect( importButton ).toHaveClass( 'primary' );
+    expect( importButton ).toBeInTheDocument();
+    expect( importButton ).toBeInstanceOf( HTMLButtonElement );
   } );
 
 
@@ -166,6 +172,8 @@ describe( 'ImportButton', () => {
 
     // Test expectations.
     expect( importButton ).toHaveClass( 'primary' );
+    expect( importButton ).toBeInTheDocument();
+    expect( importButton ).toBeInstanceOf( HTMLButtonElement );
     expect( consoleSpy ).toHaveBeenCalled();
     expect( consoleSpy ).toHaveBeenCalledWith( 'Handle import fired!' );
     expect( consoleSpy ).toHaveBeenCalledTimes( 1 );

--- a/tests/js/ImportButton.test.tsx
+++ b/tests/js/ImportButton.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ImportButton from '../../src/components/ImportButton';
+
+jest.mock( '@wordpress/i18n', () => ( {
+  __: jest.fn( ( arg ) => arg )
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+  Button: jest.fn( ( { children, variant, onClick } ) => {
+    return (
+      <>
+        <button className={ variant } onClick={ onClick }>
+          { children }
+        </button>
+      </>
+    )
+  } )
+} ) );
+
+const handleUpload = jest.fn(
+  () => console.log( 'Handle upload fired!' )
+);
+
+const handleImport = jest.fn(
+  () => console.log( 'Handle import fired!' )
+);
+
+describe( 'ImportButton', () => {
+  it( 'renders the button with "Upload SQL File" text', () => {
+    const parsedSQL = {
+      tableName: 'student',
+      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+      tableRows: [],
+    }
+
+    const { container } = render(
+      <ImportButton
+        parsedSQL={ parsedSQL }
+        handleUpload={ handleUpload }
+        handleImport={ handleImport }
+      />
+    );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe(
+      `<button class="primary">Upload SQL File</button>`
+    );
+
+    // Assert the button is displayed.
+    const uploadButton = screen.getByRole( 'button' );
+    expect( uploadButton ).toHaveClass( 'primary' );
+  } );
+
+
+  it( 'logs "Handle upload fired!" when the upload button is clicked', () => {
+    const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation( () => { } );
+
+    const parsedSQL = {
+      tableName: 'student',
+      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+      tableRows: []
+    }
+
+    const { container } = render(
+      <ImportButton
+        parsedSQL={ parsedSQL }
+        handleUpload={ handleUpload }
+        handleImport={ handleImport }
+      />
+    );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe(
+      `<button class="primary">Upload SQL File</button>`
+    );
+
+    // Assert the button is displayed.
+    const uploadButton = screen.getByRole( 'button' );
+
+    // Click upload button.
+    fireEvent.click( uploadButton );
+
+    // Test expectations.
+    expect( uploadButton ).toHaveClass( 'primary' );
+    expect( consoleSpy ).toHaveBeenCalled();
+    expect( consoleSpy ).toHaveBeenCalledWith( 'Handle upload fired!' );
+    expect( consoleSpy ).toHaveBeenCalledTimes( 1 );
+
+    // Clean up.
+    consoleSpy.mockRestore();
+  } );
+
+
+  it( 'renders the button with "Convert to CPT" text', () => {
+    const parsedSQL = {
+      tableName: 'student',
+      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+      tableRows: [
+        [
+          1,
+          'John Doe',
+          37,
+          'M',
+          'john@doe.com'
+        ]
+      ]
+    }
+
+    const { container } = render(
+      <ImportButton
+        parsedSQL={ parsedSQL }
+        handleUpload={ handleUpload }
+        handleImport={ handleImport }
+      />
+    );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe(
+      `<button class="primary">Convert to CPT</button>`
+    );
+
+    // Assert the button is displayed.
+    const importButton = screen.getByRole( 'button' );
+    expect( importButton ).toHaveClass( 'primary' );
+  } );
+
+
+  it( 'logs "Handle import fired!" when the import button is clicked', () => {
+    const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation( () => { } );
+
+    const parsedSQL = {
+      tableName: 'student',
+      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+      tableRows: [
+        [
+          1,
+          'John Doe',
+          37,
+          'M',
+          'john@doe.com'
+        ]
+      ]
+    }
+
+    const { container } = render(
+      <ImportButton
+        parsedSQL={ parsedSQL }
+        handleUpload={ handleUpload }
+        handleImport={ handleImport }
+      />
+    );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe(
+      `<button class="primary">Convert to CPT</button>`
+    );
+
+    // Assert the button is displayed.
+    const importButton = screen.getByRole( 'button' );
+
+    // Click upload button.
+    fireEvent.click( importButton );
+
+    // Test expectations.
+    expect( importButton ).toHaveClass( 'primary' );
+    expect( consoleSpy ).toHaveBeenCalled();
+    expect( consoleSpy ).toHaveBeenCalledWith( 'Handle import fired!' );
+    expect( consoleSpy ).toHaveBeenCalledTimes( 1 );
+
+    // Clean up.
+    consoleSpy.mockRestore();
+  } );
+} );

--- a/tests/js/Notice.test.tsx
+++ b/tests/js/Notice.test.tsx
@@ -20,4 +20,11 @@ describe( 'Notice', () => {
     expect( nav ).toBeInTheDocument();
     expect( nav ).toBeInstanceOf( HTMLElement );
   } );
+
+  it( 'DOES NOT render the Notice', () => {
+    const { container } = render( <Notice message="" /> );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe( `` );
+  } );
 } );

--- a/tests/js/Notice.test.tsx
+++ b/tests/js/Notice.test.tsx
@@ -13,7 +13,7 @@ describe( 'Notice', () => {
       `<nav>Fatal Error! Wrong file type: sample-1.png</nav>`
     );
 
-    // Assert the text content is rendered inside the nav element
+    // Assert the text content is rendered inside the nav element.
     const nav = screen.getByText( 'Fatal Error! Wrong file type: sample-1.png' );
     const navName = nav.tagName.toLowerCase();
     expect( navName ).toBe( 'nav' );

--- a/tests/js/Notice.test.tsx
+++ b/tests/js/Notice.test.tsx
@@ -14,8 +14,10 @@ describe( 'Notice', () => {
     );
 
     // Assert the text content is rendered inside the nav element
-    const navText = screen.getByText( 'Fatal Error! Wrong file type: sample-1.png' );
-    const navName = navText.tagName.toLowerCase();
+    const nav = screen.getByText( 'Fatal Error! Wrong file type: sample-1.png' );
+    const navName = nav.tagName.toLowerCase();
     expect( navName ).toBe( 'nav' );
+    expect( nav ).toBeInTheDocument();
+    expect( nav ).toBeInstanceOf( HTMLElement );
   } );
 } );

--- a/tests/js/ProgressBar.test.tsx
+++ b/tests/js/ProgressBar.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ProgressBar from '../../src/components/ProgressBar';
+
+describe( 'ProgressBar', () => {
+  it( 'renders the Progress Bar', () => {
+    const { container } = render( <ProgressBar isLoading={true} progress={75} /> );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe(
+      `<div class="sqlt-cpt-progress-bar" role="progressbar"><div><div style="width: 75%;"></div></div><p>75%</p></div>`
+    );
+
+    // Assert the ProgressBar is rendered and is disabled
+    const progressBar = screen.getByRole( 'progressbar' );
+    expect( progressBar ).toBeInTheDocument();
+    expect( progressBar ).toBeInstanceOf( HTMLDivElement );
+    expect( progressBar ).toContainHTML( '<div><div style="width: 75%;"></div></div><p>75%</p>' );
+  } );
+
+
+  it( 'DOES NOT render the Progress Bar', () => {
+    const { container } = render( <ProgressBar isLoading={false} progress={75} /> );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe( `` );
+  } );
+} );

--- a/tests/js/ProgressBar.test.tsx
+++ b/tests/js/ProgressBar.test.tsx
@@ -13,7 +13,7 @@ describe( 'ProgressBar', () => {
       `<div class="sqlt-cpt-progress-bar" role="progressbar"><div><div style="width: 75%;"></div></div><p>75%</p></div>`
     );
 
-    // Assert the ProgressBar is rendered and is disabled
+    // Assert the ProgressBar is rendered and is disabled.
     const progressBar = screen.getByRole( 'progressbar' );
     expect( progressBar ).toBeInTheDocument();
     expect( progressBar ).toBeInstanceOf( HTMLDivElement );

--- a/tests/js/ProgressBar.test.tsx
+++ b/tests/js/ProgressBar.test.tsx
@@ -20,7 +20,6 @@ describe( 'ProgressBar', () => {
     expect( progressBar ).toContainHTML( '<div><div style="width: 75%;"></div></div><p>75%</p>' );
   } );
 
-
   it( 'DOES NOT render the Progress Bar', () => {
     const { container } = render( <ProgressBar isLoading={false} progress={75} /> );
 

--- a/tests/js/TableColumns.test.tsx
+++ b/tests/js/TableColumns.test.tsx
@@ -34,6 +34,7 @@ describe( 'TableColumns', () => {
     // Assert the Table Columns are displayed.
     const tableColumns = screen.getByRole('list');
     expect( tableColumns ).toHaveClass( 'sqlt-cpt-table-columns' );
+    expect( tableColumns ).toBeInTheDocument();
     expect( tableColumns ).toBeInstanceOf( HTMLDivElement );
     expect( tableColumns ).toContainHTML( '<h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p>' );
   } );

--- a/tests/js/TableColumns.test.tsx
+++ b/tests/js/TableColumns.test.tsx
@@ -32,7 +32,7 @@ describe( 'TableColumns', () => {
     );
 
     // Assert the Table Columns are displayed.
-    const tableColumns = screen.getByRole('list');
+    const tableColumns = screen.getByRole( 'list' );
     expect( tableColumns ).toHaveClass( 'sqlt-cpt-table-columns' );
     expect( tableColumns ).toBeInTheDocument();
     expect( tableColumns ).toBeInstanceOf( HTMLDivElement );

--- a/tests/js/TableColumns.test.tsx
+++ b/tests/js/TableColumns.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import TableColumns from '../../src/components/TableColumns';
+
+jest.mock( '@wordpress/i18n', () => ( {
+  __: jest.fn( ( arg ) => arg )
+} ) );
+
+describe( 'TableColumns', () => {
+  it( 'renders the Table Columns', () => {
+    const parsedSQL = {
+      tableName: 'student',
+      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+      tableRows: [
+        [
+          1,
+          'John Doe',
+          37,
+          'M',
+          'john@doe.com'
+        ]
+      ]
+    }
+
+    const { container } = render( <TableColumns parsedSQL={ parsedSQL } /> );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe(
+      `<div class="sqlt-cpt-table-columns" role="list"><h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p></div>`
+    );
+
+    // Assert the Table Columns are displayed.
+    const tableColumns = screen.getByRole('list');
+    expect( tableColumns ).toHaveClass( 'sqlt-cpt-table-columns' );
+    expect( tableColumns ).toBeInstanceOf( HTMLDivElement );
+    expect( tableColumns ).toContainHTML( '<h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p>' );
+  } );
+
+  it( 'DOES NOT render the Table Columns', () => {
+    const parsedSQL = {
+      tableName: 'student',
+      tableColumns: [],
+      tableRows: [
+        [
+          1,
+          'John Doe',
+          37,
+          'M',
+          'john@doe.com'
+        ]
+      ]
+    }
+
+    const { container } = render( <TableColumns parsedSQL={ parsedSQL } /> );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe( `` );
+  } );
+} );

--- a/tests/js/TableName.test.tsx
+++ b/tests/js/TableName.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import TableName from '../../src/components/TableName';
+
+jest.mock( '@wordpress/i18n', () => ( {
+  __: jest.fn( ( arg ) => arg )
+} ) );
+
+describe( 'TableName', () => {
+  it( 'renders the Table Name and its input', () => {
+    const parsedSQL = {
+      tableName: 'student',
+      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+      tableRows: [
+        [
+          1,
+          'John Doe',
+          37,
+          'M',
+          'john@doe.com'
+        ]
+      ]
+    }
+
+    const { container } = render( <TableName parsedSQL={ parsedSQL } /> );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe(
+      `<div class="sqlt-cpt-table-name" role="list"><h3>Table</h3><p><input type="text" disabled="" value="student"></p></div>`
+    );
+
+    // Assert the Table Name is displayed.
+    const tableName = screen.getByRole( 'list' );
+    expect( tableName ).toHaveClass( 'sqlt-cpt-table-name' );
+    expect( tableName ).toBeInTheDocument();
+    expect( tableName ).toBeInstanceOf( HTMLDivElement );
+  } );
+
+  it( 'DOES NOT render the Table Name', () => {
+    const parsedSQL = {
+      tableName: '',
+      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+      tableRows: [
+        [
+          1,
+          'John Doe',
+          37,
+          'M',
+          'john@doe.com'
+        ]
+      ]
+    }
+
+    const { container } = render( <TableName parsedSQL={ parsedSQL } /> );
+
+    // Expect Component to look like so:
+    expect( container.innerHTML ).toBe( `` );
+  } );
+} );

--- a/tests/js/TextInput.test.tsx
+++ b/tests/js/TextInput.test.tsx
@@ -16,5 +16,7 @@ describe( 'TextInput', () => {
     // Assert the input is rendered and is disabled
     const input = screen.getByRole( 'textbox' );
     expect( input ).toHaveValue( 'post_title' );
+    expect( input ).toBeInTheDocument();
+    expect( input ).toBeInstanceOf( HTMLInputElement );
   } );
 } );

--- a/tests/js/TextInput.test.tsx
+++ b/tests/js/TextInput.test.tsx
@@ -13,7 +13,7 @@ describe( 'TextInput', () => {
       `<p><input type="text" value="post_title"></p>`
     );
 
-    // Assert the input is rendered and is disabled
+    // Assert the input is rendered and is disabled.
     const input = screen.getByRole( 'textbox' );
     expect( input ).toHaveValue( 'post_title' );
     expect( input ).toBeInTheDocument();


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/8).

## Description / Background Context

This PR introduces additional tests for the newly added components from the last release.

## Testing Instructions

1. Pull PR to local.
2. Run tests like so: `yarn test:js`.
3. All tests should pass like so:

```bash
$ yarn test:js

yarn run v1.22.18
$ jest --passWithNoTests
 PASS  tests/js/Notice.test.tsx
 PASS  tests/js/TextInput.test.tsx
 PASS  tests/js/Disabled.test.tsx
 PASS  tests/js/TableColumns.test.tsx
 PASS  tests/js/ImportButton.test.tsx
 PASS  tests/js/ProgressBar.test.tsx

Test Suites: 6 passed, 6 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        3.925 s, estimated 5 s
Ran all test suites.
✨  Done in 5.72s.
```