### PR TITLE
Fix: Breaking WP dependency & Parser Injection via DI

### DIFF
--- a/inc/Core/Parser.php
+++ b/inc/Core/Parser.php
@@ -23,18 +23,6 @@ class Parser {
 	public string $sql;
 
 	/**
-	 * Set up.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $sql
-	 * @return void
-	 */
-	public function __construct( $sql ) {
-		$this->sql = $sql;
-	}
-
-	/**
 	 * Get SQL.
 	 *
 	 * This method is responsible for grabbing the
@@ -189,10 +177,14 @@ class Parser {
 	 * and sending back the parsed data.
 	 *
 	 * @since 1.0.0
+	 * @since 1.2.2 Pass in SQL source path.
 	 *
+	 * @param string $sql SQL string.
 	 * @return array
 	 */
-	public function get_parsed_sql(): array {
+	public function get_parsed_sql( $sql ): array {
+		$this->sql = $sql;
+
 		return [
 			'tableName'    => $this->get_sql_table_name(),
 			'tableColumns' => $this->get_sql_table_columns(),

--- a/inc/Routes/Parse.php
+++ b/inc/Routes/Parse.php
@@ -94,7 +94,9 @@ class Parse extends Route implements Router {
 			);
 		}
 
-		return new \WP_REST_Response( $this->get_response() );
+		$response = $this->get_response( new Parser() );
+
+		return new \WP_REST_Response( $response );
 	}
 
 	/**
@@ -105,12 +107,11 @@ class Parse extends Route implements Router {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Parser $parser SQL Parser instance.
 	 * @return mixed[]
 	 */
-	protected function get_response(): array {
-		$parser = new Parser( $this->file );
-
-		return $parser->get_parsed_sql();
+	protected function get_response( Parser $parser ): array {
+		return $parser->get_parsed_sql( $this->file );
 	}
 
 	/**

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -56,7 +56,6 @@ class Boot extends Service implements Kernel {
 				'wp-compose',
 				'wp-plugins',
 				'wp-edit-post',
-				'wp-edit-site',
 			],
 			'1.2.0',
 			false,

--- a/tests/php/Core/ParserTest.php
+++ b/tests/php/Core/ParserTest.php
@@ -8,7 +8,6 @@ use WP_Mock\Tools\TestCase;
 use SqlToCpt\Core\Parser;
 
 /**
- * @covers \SqlToCpt\Core\Parser::__construct
  * @covers \SqlToCpt\Core\Parser::get_sql_string
  * @covers \SqlToCpt\Core\Parser::get_sql_table_name
  * @covers \SqlToCpt\Core\Parser::get_sql_table_columns

--- a/tests/php/Routes/ParseTest.php
+++ b/tests/php/Routes/ParseTest.php
@@ -14,7 +14,6 @@ use SqlToCpt\Abstracts\Service;
  * @covers \SqlToCpt\Routes\Parse::response
  * @covers \SqlToCpt\Routes\Parse::get_response
  * @covers \SqlToCpt\Abstracts\Route::get_400_response
- * @covers \SqlToCpt\Core\Parser::__construct
  * @covers \SqlToCpt\Core\Parser::get_parsed_sql
  * @covers \SqlToCpt\Core\Parser::get_sql_string
  * @covers \SqlToCpt\Core\Parser::get_sql_table_name

--- a/tests/php/Routes/ParseTest.php
+++ b/tests/php/Routes/ParseTest.php
@@ -4,6 +4,8 @@ namespace SqlToCpt\Tests\Routes;
 
 use Mockery;
 use WP_Mock\Tools\TestCase;
+
+use SqlToCpt\Core\Parser;
 use SqlToCpt\Routes\Parse;
 use SqlToCpt\Abstracts\Service;
 
@@ -188,6 +190,9 @@ class ParseTest extends TestCase {
 		$parse = Mockery::mock( Parse::class )->makePartial();
 		$parse->shouldAllowMockingProtectedMethods();
 
+		$parser = Mockery::mock( Parser::class )->makePartial();
+		$parser->shouldAllowMockingProtectedMethods();
+
 		$parse->file = '';
 
 		\WP_Mock::userFunction( 'esc_url' )
@@ -200,7 +205,7 @@ class ParseTest extends TestCase {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Fatal Error: File does not exist: ' );
 
-		return $parse->get_response();
+		return $parse->get_response( $parser );
 	}
 
 	public function create_mock_file( $mock_file ) {

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -114,7 +114,6 @@ class BootTest extends TestCase {
 					'wp-compose',
 					'wp-plugins',
 					'wp-edit-post',
-					'wp-edit-site',
 				],
 				'1.2.0',
 				false,


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/13).

## Description / Background Context

This PR introduces a fix for the breaking WP dependency and also passes the Parser $instance via DI so that we can correctly mock our unit tests.

## Testing Instructions

1. Pull PR to local.
2. Run test like so: `composer run test`
3. All tests should pass correctly like so:

```
Time: 00:00.070, Memory: 12.00 MB

OK (72 tests, 122 assertions)
```