### PR TITLE
Fix: Ensure REST response on SQL Import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Fix: Ensure REST response on SQL Import.
+
 ## 1.2.2
 * Refactor: Parser instance via DI logic.
 * Fix: Breaking WP dependency.

--- a/inc/Routes/Import.php
+++ b/inc/Routes/Import.php
@@ -97,7 +97,15 @@ class Import extends Route implements Router {
 			);
 		}
 
-		return new \WP_REST_Response( $this->get_response() );
+		$response = $this->get_response();
+
+		if ( is_null( $response ) ) {
+			return $this->get_400_response(
+				__( 'Error: Failed SQL Import!', 'sql-to-cpt' )
+			);
+		}
+
+		return rest_ensure_response( $this->get_response() );
 	}
 
 	/**

--- a/tests/php/Routes/ImportTest.php
+++ b/tests/php/Routes/ImportTest.php
@@ -225,7 +225,7 @@ class ImportTest extends TestCase {
 
 		\WP_Mock::userFunction( '__' )
 			->andReturnUsing(
-				function( $arg ) {
+				function ( $arg ) {
 					return $arg;
 				}
 			);


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/16).

## Description / Background Context

Previously the REST response obtained on SQL import was being typecast to the `WP_REST_Response` type. This PR fixes this issue by using the `rest_ensure_response` method to safely return a valid REST Response.

## Testing Instructions

1. Pull PR to local.
2. Run test like so: `composer run test`
3. All tests should pass and plugin should be able to import SQL files as before.

```
Time: 00:00.070, Memory: 12.00 MB

OK (72 tests, 122 assertions)
```