### PR TITLE
Feat: Add Progress bar to Parse action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Fix: Ensure REST response on SQL Import.
+* Feat: Add Progress bar to Parse activity.
 
 ## 1.2.2
 * Refactor: Parser instance via DI logic.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -77,9 +77,15 @@ const App = (): JSX.Element => {
         tableRows: [],
       }
     );
+    setProgress( 0 );
+    setIsLoading( true );
 
     // Parse SQL.
     try {
+      const progressInterval = setInterval( () => {
+        setProgress( ( prev ) => ( prev < 90 ? prev + 10 : prev ) );
+      }, 500 );
+
       setParsedSQL(
         await apiFetch(
           {
@@ -91,6 +97,10 @@ const App = (): JSX.Element => {
           }
         )
       );
+
+      clearInterval( progressInterval );
+      setProgress( 100 );
+      setIsLoading( false );
     } catch ( { message } ) {
       setSqlNotice( message );
     }
@@ -111,9 +121,9 @@ const App = (): JSX.Element => {
     setIsLoading( true );
 
     try {
-      const progressInterval = setInterval(() => {
-        setProgress((prev) => (prev < 90 ? prev + 10 : prev));
-      }, 500);
+      const progressInterval = setInterval( () => {
+        setProgress( ( prev ) => ( prev < 90 ? prev + 10 : prev ) );
+      }, 500 );
 
       const url = await apiFetch(
         {


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/18).

## Description / Background Context

When users are uploading an SQL file on a slow network, we need to show the Progress bar to at least keep them occupied while the SQL file is being parsed. This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Set your browser's network connection to **3G**.
3. Upload an SQL file to see the Progress bar.
4. You should now see the **Progress bar** loading while the SQL file is being parsed.

<img width="1351" alt="parse-progress-bar" src="https://github.com/user-attachments/assets/250a78cd-7961-4c04-ae1a-748ca2bc042a" />