### PR TITLE
Refactor: Move Interval logic to Progress Bar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Fix: Ensure REST response on SQL Import.
 * Feat: Add Progress bar to Parse activity.
+* Refactor: Move Interval logic to Progress Bar component.
 
 ## 1.2.2
 * Refactor: Parser instance via DI logic.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,10 +28,9 @@ interface SQLProps {
  * @returns {JSX.Element}
  */
 const App = (): JSX.Element => {
-  const [progress, setProgress]   = useState<number>(0);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [sqlNotice, setSqlNotice] = useState<string>('');
-  const [parsedSQL, setParsedSQL] = useState<SQLProps>(
+  const [ isLoading, setIsLoading ] = useState<boolean>( false );
+  const [ sqlNotice, setSqlNotice ] = useState<string>( '' );
+  const [ parsedSQL, setParsedSQL ] = useState<SQLProps>(
     {
       tableName: '',
       tableColumns: [],
@@ -77,15 +76,10 @@ const App = (): JSX.Element => {
         tableRows: [],
       }
     );
-    setProgress( 0 );
     setIsLoading( true );
 
     // Parse SQL.
     try {
-      const progressInterval = setInterval( () => {
-        setProgress( ( prev ) => ( prev < 90 ? prev + 10 : prev ) );
-      }, 500 );
-
       setParsedSQL(
         await apiFetch(
           {
@@ -97,11 +91,9 @@ const App = (): JSX.Element => {
           }
         )
       );
-
-      clearInterval( progressInterval );
-      setProgress( 100 );
       setIsLoading( false );
     } catch ( { message } ) {
+      setIsLoading( false );
       setSqlNotice( message );
     }
   };
@@ -117,14 +109,10 @@ const App = (): JSX.Element => {
    * @returns Promise<void>
    */
   const handleImport = async (): Promise<void> => {
-    setProgress( 0 );
     setIsLoading( true );
 
+    // Import SQL.
     try {
-      const progressInterval = setInterval( () => {
-        setProgress( ( prev ) => ( prev < 90 ? prev + 10 : prev ) );
-      }, 500 );
-
       const url = await apiFetch(
         {
           path: '/sql-to-cpt/v1/import',
@@ -134,14 +122,12 @@ const App = (): JSX.Element => {
           },
         }
       );
-
-      clearInterval( progressInterval );
-      setProgress( 100 );
-
       if ( url ) {
         window.location.href = `${url}`
       }
+      setIsLoading( false );
     } catch ( { message } ) {
+      setIsLoading( false );
       setSqlNotice( message );
     }
   }
@@ -155,7 +141,6 @@ const App = (): JSX.Element => {
       />
       <Notice message={ sqlNotice } />
       <ProgressBar
-        progress={ progress }
         isLoading={ isLoading }
       />
       <TableName

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,3 +1,9 @@
+import { useState, useEffect } from '@wordpress/element';
+
+interface ProgressBarProps {
+  isLoading: boolean;
+}
+
 /**
  * Progress Bar Component.
  *
@@ -5,10 +11,31 @@
  * used to display a Progress Bar.
  *
  * @since 1.2.0
+ * @since 1.3.0 Implement Interval logic.
+ *
+ * @param {boolean} isLoading True|False.
  *
  * @returns {JSX.Element}
  */
-const ProgressBar = ({ isLoading, progress }): JSX.Element => {
+const ProgressBar = ({ isLoading }: ProgressBarProps): JSX.Element => {
+  const [ progress, setProgress ] = useState<number>( 0 );
+
+  useEffect( () => {
+    let progressInterval: string | number | NodeJS.Timeout;
+
+    if ( isLoading ) {
+      setProgress( 0 );
+      progressInterval = setInterval( () => {
+        setProgress( ( prev ) => ( prev < 90 ? prev + 10 : prev ) );
+      }, 500 );
+    } else {
+      setProgress( 0 );
+      clearInterval( progressInterval );
+    }
+
+    return () => clearInterval( progressInterval );
+  }, [ isLoading ] );
+
   return (
     <>
       {

--- a/tests/js/ProgressBar.test.tsx
+++ b/tests/js/ProgressBar.test.tsx
@@ -6,22 +6,22 @@ import ProgressBar from '../../src/components/ProgressBar';
 
 describe( 'ProgressBar', () => {
   it( 'renders the Progress Bar', () => {
-    const { container } = render( <ProgressBar isLoading={true} progress={75} /> );
+    const { container } = render( <ProgressBar isLoading={true} /> );
 
     // Expect Component to look like so:
     expect( container.innerHTML ).toBe(
-      `<div class="sqlt-cpt-progress-bar" role="progressbar"><div><div style="width: 75%;"></div></div><p>75%</p></div>`
+      `<div class="sqlt-cpt-progress-bar" role="progressbar"><div><div style="width: 0%;"></div></div><p>0%</p></div>`
     );
 
     // Assert the ProgressBar is rendered and is disabled.
     const progressBar = screen.getByRole( 'progressbar' );
     expect( progressBar ).toBeInTheDocument();
     expect( progressBar ).toBeInstanceOf( HTMLDivElement );
-    expect( progressBar ).toContainHTML( '<div><div style="width: 75%;"></div></div><p>75%</p>' );
+    expect( progressBar ).toContainHTML( '<div><div style="width: 0%;"></div></div><p>0%</p>' );
   } );
 
   it( 'DOES NOT render the Progress Bar', () => {
-    const { container } = render( <ProgressBar isLoading={false} progress={75} /> );
+    const { container } = render( <ProgressBar isLoading={false} /> );
 
     // Expect Component to look like so:
     expect( container.innerHTML ).toBe( `` );


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/20).

## Description / Background Context

This PR abstracts away the Interval logic to the `ProgressBar` component. In this way, we can use as many copies of this component without having to re-implement the Interval logic.

## Testing Instructions

1. Pull PR to local.
2. Set your browser's network connection to **3G**.
3. Upload an SQL file to see the Progress bar.
4. The **Progress bar** should work as correctly as before:

<img width="1351" alt="parse-progress-bar" src="https://github.com/user-attachments/assets/250a78cd-7961-4c04-ae1a-748ca2bc042a" />