### PR TITLE
Feat: Implement Purge Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Fix: Ensure REST response on SQL Import.
 * Feat: Add Progress bar to Parse activity.
+* Feat: Implement Purge component.
 * Refactor: Move Interval logic to Progress Bar component.
 
 ## 1.2.2

--- a/inc/Routes/Purge.php
+++ b/inc/Routes/Purge.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Purge Route.
+ *
+ * This route is responsible for removing the Custom
+ * Post type and its contents.
+ *
+ * @package SqlToCpt
+ */
+
+namespace SqlToCpt\Routes;
+
+use SqlToCpt\Abstracts\Route;
+use SqlToCpt\Interfaces\Router;
+
+/**
+ * Purge class.
+ */
+class Purge extends Route implements Router {
+	/**
+	 * Get, Post, Put, Patch, Delete.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var string
+	 */
+	public string $method = 'POST';
+
+	/**
+	 * WP REST Endpoint e.g. /wp-json/sql-to-cpt/v1/purge.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var string
+	 */
+	public string $endpoint = '/purge';
+
+	/**
+	 * WP_REST_Request object.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var \WP_REST_Request
+	 */
+	public \WP_REST_Request $request;
+
+	/**
+	 * JSON Params.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var array
+	 */
+	public array $args;
+
+	/**
+	 * Custom Post type.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var string
+	 */
+	public string $post_type;
+
+	/**
+	 * Response Callback.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function response() {
+		$this->args = $this->request->get_json_params();
+
+		$this->post_type = $this->args['postType'] ?? '';
+
+		// Bail out, if bad request.
+		if ( empty( $this->post_type ) ) {
+			return $this->get_400_response(
+				sprintf(
+					'Empty Post type: %s',
+					$post_type
+				)
+			);
+		}
+
+		$deleted_posts = $this->get_response();
+
+		if ( empty( $deleted_posts ) ) {
+			return $this->get_400_response(
+				sprintf(
+					'Unable to delete Posts for CPT: %s',
+					$this->post_type
+				)
+			);
+		}
+
+		return rest_ensure_response( $deleted_posts );
+	}
+
+	/**
+	 * Get Response for valid WP REST request.
+	 *
+	 * This method obtains the response from the delete
+	 * post operations.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	protected function get_response(): array {
+		$deleted_posts = [];
+
+		foreach ( $this->get_post_ids() as $post ) {
+			$deleted_post = wp_delete_post( $post, true );
+
+			if ( ! $deleted_post ) {
+				error_log(
+					sprintf( 'Unable to delete the Post with ID: %d', $post )
+				);
+				continue;
+			}
+
+			$deleted_posts[] = $post;
+		}
+
+		return $deleted_posts;
+	}
+
+	/**
+	 * Get list of Post IDs.
+	 *
+	 * This method obtains the list of IDs for the
+	 * custom post type.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	protected function get_post_ids(): array {
+		return wp_list_pluck(
+			get_posts(
+				[
+					'post_type'   => $this->post_type,
+					'numberposts' => -1,
+				]
+			),
+			'ID'
+		);
+	}
+}

--- a/inc/Routes/Purge.php
+++ b/inc/Routes/Purge.php
@@ -115,7 +115,7 @@ class Purge extends Route implements Router {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return \WP_REST_Response|\WP_Error
+	 * @return mixed[]
 	 */
 	protected function get_response(): array {
 		$undeleted_posts = [];
@@ -146,7 +146,7 @@ class Purge extends Route implements Router {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return \WP_REST_Response|\WP_Error
+	 * @return mixed[]
 	 */
 	protected function get_post_ids(): array {
 		return wp_list_pluck(

--- a/inc/Routes/Purge.php
+++ b/inc/Routes/Purge.php
@@ -121,9 +121,7 @@ class Purge extends Route implements Router {
 		$undeleted_posts = [];
 
 		foreach ( $this->get_post_ids() as $post_id ) {
-			$deleted_post = wp_delete_post( $post_id, true );
-
-			if ( ! $deleted_post ) {
+			if ( ! wp_delete_post( $post_id, true ) ) {
 				error_log(
 					sprintf(
 						'Unable to delete the Post ID: %d',

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -64,6 +64,15 @@ class Boot extends Service implements Kernel {
 		// Handle undefined (reading 'limitExceeded') issue.
 		wp_enqueue_media();
 
+		// Localize CPTs.
+		wp_localize_script(
+			'sql-to-cpt',
+			'sqlt',
+			[
+				'postTypes' => get_option( 'sql_to_cpt', [] )['cpts'] ?? [],
+			]
+		);
+
 		// Set Translation.
 		wp_set_script_translations(
 			'sql-to-cpt',

--- a/inc/Services/Routes.php
+++ b/inc/Services/Routes.php
@@ -12,6 +12,7 @@
 namespace SqlToCpt\Services;
 
 use SqlToCpt\Routes\Parse;
+use SqlToCpt\Routes\Purge;
 use SqlToCpt\Routes\Import;
 use SqlToCpt\Abstracts\Service;
 use SqlToCpt\Interfaces\Kernel;
@@ -37,6 +38,7 @@ class Routes extends Service implements Kernel {
 		$this->routes = [
 			Parse::class,
 			Import::class,
+			Purge::class,
 		];
 	}
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,6 +7,7 @@ import ProgressBar from '../components/ProgressBar';
 import ImportButton from '../components/ImportButton';
 import TableName from '../components/TableName';
 import TableColumns from '../components/TableColumns';
+import Purge from '../components/Purge';
 
 import { getModalParams } from '../utils';
 import '../styles/app.scss';
@@ -148,14 +149,19 @@ const App = (): JSX.Element => {
 
   return (
     <main>
-      <ImportButton
-        parsedSQL={ parsedSQL }
-        handleImport={ handleImport }
-        handleUpload={ handleUpload }
-      />
+      <section>
+        <ImportButton
+          parsedSQL={ parsedSQL }
+          handleImport={ handleImport }
+          handleUpload={ handleUpload }
+        />
+        <Purge
+          setIsLoading={ setIsLoading }
+          setSqlNotice={ setSqlNotice }
+        />
+      </section>
       <Notice message={ sqlNotice } />
       <ProgressBar
-        progress={ progress }
         isLoading={ isLoading }
       />
       <TableName

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,12 +2,12 @@ import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
 import type { MediaFrame } from '@wordpress/media-utils';
 
+import Purge from '../components/Purge';
 import Notice from '../components/Notice';
 import ProgressBar from '../components/ProgressBar';
 import ImportButton from '../components/ImportButton';
 import TableName from '../components/TableName';
 import TableColumns from '../components/TableColumns';
-import Purge from '../components/Purge';
 
 import { getModalParams } from '../utils';
 import '../styles/app.scss';

--- a/src/components/Purge.tsx
+++ b/src/components/Purge.tsx
@@ -30,6 +30,7 @@ const Purge = ({ setIsLoading, setSqlNotice }): JSX.Element => {
         }
       );
       setIsLoading( false );
+      window.location.reload();
     } catch ( { message } ) {
       setIsLoading( false );
       setSqlNotice( message );
@@ -39,9 +40,16 @@ const Purge = ({ setIsLoading, setSqlNotice }): JSX.Element => {
   return (
     <div className="sqlt-purge">
       <select
-        onChange={ () => {} }
+        onChange={ ( e ) => { setPostType( e.target.value ) } }
       >
         <option>Select CPT</option>
+        {
+          sqlt.postTypes.map( ( item: string ) => {
+            return (
+              <option>{ item }</option>
+            )
+          } )
+        }
       </select>
       <Button
         variant="tertiary"

--- a/src/components/Purge.tsx
+++ b/src/components/Purge.tsx
@@ -1,0 +1,56 @@
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Purge Component.
+ *
+ * This function returns a JSX component that is
+ * used to purge the CPT and its contents.
+ *
+ * @since 1.3.0
+ *
+ * @returns {JSX.Element}
+ */
+const Purge = ({ setIsLoading, setSqlNotice }): JSX.Element => {
+  const [ postType, setPostType ] = useState( '' );
+
+  const handlePurge = async () => {
+    setIsLoading( true );
+
+    try {
+      await apiFetch(
+        {
+          path: '/sql-to-cpt/v1/purge',
+          method: 'POST',
+          data: {
+            postType
+          },
+        }
+      );
+      setIsLoading( false );
+    } catch ( { message } ) {
+      setIsLoading( false );
+      setSqlNotice( message );
+    }
+  }
+
+  return (
+    <div className="sqlt-purge">
+      <select
+        onChange={ () => {} }
+      >
+        <option>Select CPT</option>
+      </select>
+      <Button
+        variant="tertiary"
+        onClick={ handlePurge }
+      >
+        { __( 'Purge CPT', 'sql-to-cpt' ) }
+      </Button>
+    </div>
+  );
+}
+
+export default Purge;

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,13 +1,20 @@
 #sql-to-cpt {
 	button {
 		color: #FFF;
-		background: #7F54B3;
 		padding: 11.5px 15px;
 		border-radius: 2px;
 		border: none;
 		font-size: 13px;
 		font-weight: 400 !important;
 		cursor: pointer;
+
+		&.is-primary {
+			background: #7F54B3;
+		}
+
+		&.is-tertiary {
+			background: #BA7B00;
+		}
 
 		&:hover {
 			background: #1e6ba1;
@@ -21,24 +28,44 @@
 		margin-top: 15px;
 	}
 
-	.sqlt-cpt {
-		&-progress-bar {
-			margin-top: 10px;
+	select {
+		padding: 0 28px 0 14px;
+		min-height: 40px;
+		top: -1px;
+		position: relative;
+		border-radius: 2px;
+	}
 
-			& > div {
-				width: 100%;
-				margin-top: 20;
-				background-color: #DDD;
-				border-radius: 5px;
-				overflow: hidden;
-				height: 10px;
+	section {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.sqlt {
+		&-cpt {
+			&-progress-bar {
+				margin-top: 10px;
 
 				& > div {
-					height: 100%;
-					background-color: #007cba;
-					transition: width 0.3s ease;
+					width: 100%;
+					margin-top: 20;
+					background-color: #DDD;
+					border-radius: 5px;
+					overflow: hidden;
+					height: 10px;
+
+					& > div {
+						height: 100%;
+						background-color: #007cba;
+						transition: width 0.3s ease;
+					}
 				}
 			}
+		}
+
+		&-purge {
+			display: flex;
+			gap: 10px;
 		}
 	}
 }

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  var sqlt: {
+    postTypes: string[];
+  };
+}
+
+export {};

--- a/tests/php/Routes/PurgeTest.php
+++ b/tests/php/Routes/PurgeTest.php
@@ -13,6 +13,7 @@ use SqlToCpt\Abstracts\Service;
  * @covers \SqlToCpt\Routes\Purge::get_response
  * @covers \SqlToCpt\Routes\Purge::get_post_ids
  * @covers \SqlToCpt\Routes\Purge::get_updated_cpts
+ * @covers \SqlToCpt\Abstracts\Route::get_400_response
  */
 class PurgeTest extends TestCase {
 	public Purge $purge;

--- a/tests/php/Routes/PurgeTest.php
+++ b/tests/php/Routes/PurgeTest.php
@@ -9,7 +9,6 @@ use SqlToCpt\Routes\Purge;
 use SqlToCpt\Abstracts\Service;
 
 /**
- * @covers \SqlToCpt\Routes\Purge::is_sql
  * @covers \SqlToCpt\Routes\Purge::response
  * @covers \SqlToCpt\Routes\Purge::get_response
  * @covers \SqlToCpt\Routes\Purge::get_post_ids

--- a/tests/php/Routes/PurgeTest.php
+++ b/tests/php/Routes/PurgeTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace SqlToCpt\Tests\Routes;
+
+use Mockery;
+use WP_Mock\Tools\TestCase;
+
+use SqlToCpt\Routes\Purge;
+use SqlToCpt\Abstracts\Service;
+
+/**
+ * @covers \SqlToCpt\Routes\Purge::is_sql
+ * @covers \SqlToCpt\Routes\Purge::response
+ * @covers \SqlToCpt\Routes\Purge::get_response
+ * @covers \SqlToCpt\Routes\Purge::get_post_ids
+ * @covers \SqlToCpt\Routes\Purge::get_updated_cpts
+ */
+class PurgeTest extends TestCase {
+	public Purge $purge;
+
+	public function setUp(): void {
+		\WP_Mock::setUp();
+
+		$this->purge = new Purge();
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_route_initial_values() {
+		$this->assertSame( $this->purge->method, 'POST' );
+		$this->assertSame( $this->purge->endpoint, '/purge' );
+	}
+
+	public function test_response_bails_out_if_post_type_is_empty_and_returns_wp_error() {
+		$purge = Mockery::mock( Purge::class )->makePartial();
+		$purge->shouldAllowMockingProtectedMethods();
+
+		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		$request->shouldReceive( 'get_json_params' )
+			->andReturn(
+				[
+					'postType' => '',
+				]
+			);
+
+		$purge->request = $request;
+
+		$this->assertInstanceOf( \WP_Error::class, $purge->response() );
+		$this->assertConditionsMet();
+	}
+
+	public function test_response_bails_out_if_get_response_gives_undeleted_posts_and_returns_wp_error() {
+		$purge = Mockery::mock( Purge::class )->makePartial();
+		$purge->shouldAllowMockingProtectedMethods();
+
+		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request->shouldAllowMockingProtectedMethods();
+
+		$request->shouldReceive( 'get_json_params' )
+			->andReturn(
+				[
+					'postType' => 'student',
+				]
+			);
+
+		$purge->shouldReceive( 'get_response' )
+			->andReturn( [ 1 ] );
+
+		$purge->request = $request;
+
+		$this->assertInstanceOf( \WP_Error::class, $purge->response() );
+		$this->assertConditionsMet();
+	}
+
+	public function test_response_passes_and_returns_wp_rest_response() {
+		$purge = Mockery::mock( Purge::class )->makePartial();
+		$purge->shouldAllowMockingProtectedMethods();
+
+		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request->shouldAllowMockingProtectedMethods();
+
+		$rest_response = Mockery::mock( \WP_REST_Response::class )->makePartial();
+		$rest_response->shouldAllowMockingProtectedMethods();
+
+		$request->shouldReceive( 'get_json_params' )
+			->andReturn(
+				[
+					'postType' => 'student',
+				]
+			);
+
+		$purge->shouldReceive( 'get_response' )
+			->andReturn( [] );
+
+		$purge->shouldReceive( 'get_updated_cpts' )
+			->andReturn( [ 'lecturer', 'department' ] );
+
+		\WP_Mock::userFunction( 'rest_ensure_response' )
+			->with(
+				[
+					'message'  => 'Posts deleted succesfully for custom Post Type: student',
+					'postType' => 'student',
+				]
+			)
+			->andReturn( $rest_response );
+
+		$purge->request = $request;
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $purge->response() );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_response_returns_undeleted_post_if_wp_delete_post_yields_false() {
+		$purge = Mockery::mock( Purge::class )->makePartial();
+		$purge->shouldAllowMockingProtectedMethods();
+
+		$purge->shouldReceive( 'get_post_ids' )
+			->andReturn( [ 1, 2, 3 ] );
+
+		\WP_Mock::userFunction( 'wp_delete_post' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg % 2;
+				}
+			);
+
+		$response = $purge->get_response();
+
+		$this->assertSame( [ 2 ], $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_response_returns_undeleted_posts_if_wp_delete_post_yields_null() {
+		$purge = Mockery::mock( Purge::class )->makePartial();
+		$purge->shouldAllowMockingProtectedMethods();
+
+		$purge->shouldReceive( 'get_post_ids' )
+			->andReturn( [ 1, 2, 3 ] );
+
+		\WP_Mock::userFunction( 'wp_delete_post' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return null;
+				}
+			);
+
+		$response = $purge->get_response();
+
+		$this->assertSame( [ 1, 2, 3 ], $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_response_returns_empty_array_if_wp_delete_post_passes_for_all_ids() {
+		$purge = Mockery::mock( Purge::class )->makePartial();
+		$purge->shouldAllowMockingProtectedMethods();
+
+		$purge->shouldReceive( 'get_post_ids' )
+			->andReturn( [ 1, 2, 3 ] );
+
+		\WP_Mock::userFunction( 'wp_delete_post' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		$response = $purge->get_response();
+
+		$this->assertSame( [], $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_post_ids() {
+		$purge = Mockery::mock( Purge::class )->makePartial();
+		$purge->shouldAllowMockingProtectedMethods();
+
+		$post1     = Mockery::mock( \WP_Post::class )->makePartial();
+		$post1->ID = 1;
+
+		$post2     = Mockery::mock( \WP_Post::class )->makePartial();
+		$post2->ID = 2;
+
+		$post3     = Mockery::mock( \WP_Post::class )->makePartial();
+		$post3->ID = 3;
+
+		\WP_Mock::userFunction( 'get_posts' )
+			->once()
+			->with(
+				[
+					'post_type'   => 'student',
+					'numberposts' => -1,
+				]
+			)
+			->andReturn(
+				[
+					$post1,
+					$post2,
+					$post3,
+				]
+			);
+
+		\WP_Mock::userFunction( 'wp_list_pluck' )
+			->with(
+				[
+					$post1,
+					$post2,
+					$post3,
+				],
+				'ID'
+			)
+			->andReturnUsing(
+				function ( $arg ) {
+					return array_map(
+						function ( $post ) {
+							return $post->ID;
+						},
+						$arg
+					);
+				}
+			);
+
+		$purge->post_type = 'student';
+
+		$ids = $purge->get_post_ids();
+
+		$this->assertSame( $ids, [ 1, 2, 3 ] );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_updated_cpts() {
+		$purge = Mockery::mock( Purge::class )->makePartial();
+		$purge->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'get_option' )
+			->once()
+			->with( 'sql_to_cpt', [] )
+			->andReturn(
+				[
+					'cpts' => [ 'student', 'lecturer', 'department', 'worker' ],
+				]
+			);
+
+		\WP_Mock::userFunction( 'update_option' )
+			->once()
+			->with(
+				'sql_to_cpt',
+				[
+					'cpts' => [ 'lecturer', 'department', 'worker' ],
+				]
+			)
+			->andReturn( null );
+
+		$purge->post_type = 'student';
+
+		$cpts = $purge->get_updated_cpts();
+
+		$this->assertSame( $cpts, [ 'lecturer', 'department', 'worker' ] );
+		$this->assertConditionsMet();
+	}
+}

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -131,6 +131,26 @@ class BootTest extends TestCase {
 			)
 			->andReturn( null );
 
+			\WP_Mock::userFunction( 'get_option' )
+				->once()
+				->with( 'sql_to_cpt', [] )
+				->andReturn(
+					[
+						'cpts' => [ 'student', 'department' ],
+					]
+				);
+
+		\WP_Mock::userFunction( 'wp_localize_script' )
+			->once()
+			->with(
+				'sql-to-cpt',
+				'sqlt',
+				[
+					'postTypes' => [ 'student', 'department' ],
+				]
+			)
+			->andReturn( null );
+
 		$this->boot->register_scripts();
 
 		$this->assertConditionsMet();

--- a/tests/php/Services/RoutesTest.php
+++ b/tests/php/Services/RoutesTest.php
@@ -6,6 +6,7 @@ use Mockery;
 use WP_Mock\Tools\TestCase;
 
 use SqlToCpt\Routes\Parse;
+use SqlToCpt\Routes\Purge;
 use SqlToCpt\Routes\Import;
 use SqlToCpt\Services\Routes;
 use SqlToCpt\Abstracts\Route;
@@ -44,6 +45,7 @@ class RoutesTest extends TestCase {
 			[
 				Parse::class,
 				Import::class,
+				Purge::class,
 			]
 		);
 
@@ -56,6 +58,7 @@ class RoutesTest extends TestCase {
 				[
 					Parse::class,
 					Import::class,
+					Purge::class,
 				]
 			)
 			->reply(


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/22).

## Description / Background Context

We need to implement a new **Purge** component feature that helps users remove the custom post types introduced by the plugin. This component would remove the selected CPT and its associated content like so:

<img width="320" alt="Image" src="https://github.com/user-attachments/assets/59661c1b-a799-4184-8e5f-5422f1dce04a" />

<img width="337" alt="Image" src="https://github.com/user-attachments/assets/1399d395-3442-4509-9ac2-bdd3cb6f0ca2" />

---

<img width="1119" alt="Image" src="https://github.com/user-attachments/assets/f1136c56-85a4-479b-af6a-54989429250c" />

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build repo correctly like so: `rm -rf node_modules && yarn install & yarn dev`
3. Upload an SQL file containing students.
4. Locate `Purge` component on the right hand side of the screen and select **student** option to delete it and its content.
5. It should work correctly like so:

<img width="1119" alt="Image" src="https://github.com/user-attachments/assets/f1136c56-85a4-479b-af6a-54989429250c" />