### PR TITLE
Chore: Enforce WP linting across plugin

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,5 +1,7 @@
 .babelrc
 .editorconfig
+.eslintignore
+.eslintrc.js
 .gitignore
 .github
 CHANGELOG.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,4 @@ trim_trailing_whitespace = true
 
 [*.{js,jsx,ts,tsx,json,yml,yaml,babelrc,md}]
 indent_size = 2
-indent_style = space
+indent_style = tab

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+vendor/
+build/
+dist/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	root: true,
+	extends: [ 'plugin:@wordpress/recommended' ],
+	rules: {
+		'import/no-extraneous-dependencies': 'off',
+	},
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Run JS Unit Tests
       run: |
-        yarn test
+        yarn test:js
 
     - name: Set up PHP v8.2
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,11 @@ jobs:
       run: |
         yarn install
 
-    - name: Run JS Tests
+    - name: Check JS Linting
+      run: |
+        yarn lint:js
+
+    - name: Run JS Unit Tests
       run: |
         yarn test
 
@@ -40,10 +44,10 @@ jobs:
       run: |
         composer install --prefer-dist --no-progress
 
-    - name: Run Linting
+    - name: Check PHP Linting
       run: |
         composer run lint
 
-    - name: Run PHP Tests
+    - name: Run PHP Unit Tests
       run: |
         composer run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+* Enforce WP linting style across plugin.
+
 ## 1.3.0
 * Fix: Ensure REST response on SQL Import.
 * Feat: Add Progress bar to Parse activity.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,14 @@
-const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
+const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
 
 module.exports = {
-  ...baseConfig,
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
-  setupFilesAfterEnv: [
-    './jest.setup.js'
-  ],
-  transform: {
-    '^.+\\.jsx?$': 'babel-jest',
-  },
-  moduleNameMapper: {
-    'uuid': require.resolve('uuid'),
-  },
+	...baseConfig,
+	preset: 'ts-jest',
+	testEnvironment: 'jsdom',
+	setupFilesAfterEnv: [ './jest.setup.js' ],
+	transform: {
+		'^.+\\.jsx?$': 'babel-jest',
+	},
+	moduleNameMapper: {
+		uuid: require.resolve( 'uuid' ),
+	},
 };

--- a/package.json
+++ b/package.json
@@ -6,11 +6,21 @@
   "license": "GPL-2.0-or-later",
   "homepage": "https://github.com/badasswp/sql-to-cpt#readme",
   "scripts": {
-    "start": "npm install && composer install",
-    "dev": "webpack --watch",
+    "start": "yarn boot && yarn build && yarn wp-env start",
+    "stop": "yarn wp-env stop",
+    "watch": "webpack --watch",
     "build": "webpack",
+    "boot": "composer install && yarn install",
     "test": "npm-run-all --parallel test:*",
-    "test:js": "jest --passWithNoTests"
+    "test:js": "jest --passWithNoTests",
+    "test:php": "composer run test",
+    "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:js:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "lint:php": "composer run lint",
+    "lint:php:fix": "composer run lint:fix",
+    "ci": "yarn test:js && yarn lint:js && yarn test:php && yarn lint:php",
+    "wp-env": "wp-env",
+    "bash": "wp-env run cli bash"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",
@@ -21,7 +31,6 @@
     "@testing-library/jest-dom": "5.17",
     "@testing-library/react": "15.0.6",
     "@types/jest": "^29.5.4",
-    "@wordpress/eslint-plugin": "^15.0.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,6 +14,7 @@
 	<arg name="colors" />
 	<file>.</file>
 
+	<exclude-pattern>/dist/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/languages/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.3.1 =
+* Enforce WP linting style across plugin.
+
 = 1.3.0 =
 * Fix: Ensure REST response on SQL Import.
 * Feat: Add Progress bar to Parse activity.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,9 +10,9 @@ import ImportButton from '../components/ImportButton';
 import '../styles/app.scss';
 
 interface SQLProps {
-  tableName: string;
-  tableColumns: string[];
-  tableRows: any[];
+	tableName: string;
+	tableColumns: string[];
+	tableRows: any[];
 }
 
 /**
@@ -23,45 +23,37 @@ interface SQLProps {
  *
  * @since 1.0.0
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The App component.
  */
 const App = (): JSX.Element => {
-  const [ isLoading, setIsLoading ] = useState<boolean>( false );
-  const [ sqlNotice, setSqlNotice ] = useState<string>( '' );
-  const [ parsedSQL, setParsedSQL ] = useState<SQLProps>(
-    {
-      tableName: '',
-      tableColumns: [],
-      tableRows: [],
-    }
-  );
+	const [ isLoading, setIsLoading ] = useState< boolean >( false );
+	const [ sqlNotice, setSqlNotice ] = useState< string >( '' );
+	const [ parsedSQL, setParsedSQL ] = useState< SQLProps >( {
+		tableName: '',
+		tableColumns: [],
+		tableRows: [],
+	} );
 
-  return (
-    <main>
-      <section>
-        <ImportButton
-          parsedSQL={ parsedSQL }
-          setIsLoading={ setIsLoading }
-          setSqlNotice={ setSqlNotice }
-          setParsedSQL={ setParsedSQL }
-        />
-        <Purge
-          setIsLoading={ setIsLoading }
-          setSqlNotice={ setSqlNotice }
-        />
-      </section>
-      <Notice message={ sqlNotice } />
-      <ProgressBar
-        isLoading={ isLoading }
-      />
-      <TableName
-        parsedSQL={ parsedSQL }
-      />
-      <TableColumns
-        parsedSQL={ parsedSQL }
-      />
-    </main>
-  )
-}
+	return (
+		<main>
+			<section>
+				<ImportButton
+					parsedSQL={ parsedSQL }
+					setIsLoading={ setIsLoading }
+					setSqlNotice={ setSqlNotice }
+					setParsedSQL={ setParsedSQL }
+				/>
+				<Purge
+					setIsLoading={ setIsLoading }
+					setSqlNotice={ setSqlNotice }
+				/>
+			</section>
+			<Notice message={ sqlNotice } />
+			<ProgressBar isLoading={ isLoading } />
+			<TableName parsedSQL={ parsedSQL } />
+			<TableColumns parsedSQL={ parsedSQL } />
+		</main>
+	);
+};
 
 export default App;

--- a/src/components/Disabled.tsx
+++ b/src/components/Disabled.tsx
@@ -1,5 +1,5 @@
 interface DisabledProps {
-  name: string;
+	name: string;
 }
 
 /**
@@ -10,17 +10,17 @@ interface DisabledProps {
  *
  * @since 1.0.0
  *
- * @param {Object} props - The component props.
- * @param {DisabledProps} props.message - Default Text value.
+ * @param {Object} props      - The component props.
+ * @param          props.name
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The Disabled component.
  */
 const Disabled = ( { name }: DisabledProps ): JSX.Element => {
-  return (
-    <p>
-      <input type="text" value={ name } disabled />
-    </p>
-  );
-}
+	return (
+		<p>
+			<input type="text" value={ name } disabled />
+		</p>
+	);
+};
 
 export default Disabled;

--- a/src/components/ImportButton.tsx
+++ b/src/components/ImportButton.tsx
@@ -6,14 +6,14 @@ import apiFetch from '@wordpress/api-fetch';
 import { getModalParams } from '../utils';
 
 interface ImportButtonProps {
-  parsedSQL: {
-    tableName: string;
-    tableRows: any[];
-    tableColumns: string[];
-  };
-  setIsLoading: Function;
-  setSqlNotice: Function;
-  setParsedSQL: Function;
+	parsedSQL: {
+		tableName: string;
+		tableRows: any[];
+		tableColumns: string[];
+	};
+	setIsLoading: Function;
+	setSqlNotice: Function;
+	setParsedSQL: Function;
 }
 
 /**
@@ -22,128 +22,117 @@ interface ImportButtonProps {
  * This function returns a JSX component that is
  * used to display the Import Button.
  *
+ * @param  props
  * @since 1.2.0
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The Import Button component.
  */
 const ImportButton = ( props: ImportButtonProps ): JSX.Element => {
-  const { parsedSQL, setIsLoading, setSqlNotice, setParsedSQL } = props;
+	const { parsedSQL, setIsLoading, setSqlNotice, setParsedSQL } = props;
 
-  /**
-   * Handle Upload.
-   *
-   * This function is responsible for opening the
-   * WP media modal to enable user select.
-   *
-   * @since 1.0.0
-   *
-   * @returns {void}
-   */
-  const handleUpload = (): void => {
-    const wpMediaModal = wp.media( getModalParams() );
-    wpMediaModal.on( 'select', () => handleSelect( wpMediaModal ) ).open();
-  };
+	/**
+	 * Handle Upload.
+	 *
+	 * This function is responsible for opening the
+	 * WP media modal to enable user select.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return {void}
+	 */
+	const handleUpload = (): void => {
+		const wpMediaModal = wp.media( getModalParams() );
+		wpMediaModal.on( 'select', () => handleSelect( wpMediaModal ) ).open();
+	};
 
-  /**
-   * Handle Selection.
-   *
-   * This function is responsible for handling a
-   * selection made by the user.
-   *
-   * @since 1.0.0
-   *
-   * @param {MediaFrame} wpMediaModal WP Media Modal.
-   * @returns Promise<void>
-   */
-  const handleSelect = async ( wpMediaModal: MediaFrame ): Promise<void> => {
-    const args = wpMediaModal.state().get( 'selection' ).first().toJSON();
+	/**
+	 * Handle Selection.
+	 *
+	 * This function is responsible for handling a
+	 * selection made by the user.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param {MediaFrame} wpMediaModal WP Media Modal.
+	 * @return Promise<void>
+	 */
+	const handleSelect = async (
+		wpMediaModal: MediaFrame
+	): Promise< void > => {
+		const args = wpMediaModal.state().get( 'selection' ).first().toJSON();
 
-    // Reset.
-    setSqlNotice( '' );
-    setParsedSQL(
-      {
-        tableName: '',
-        tableColumns: [],
-        tableRows: [],
-      }
-    );
-    setIsLoading( true );
+		// Reset.
+		setSqlNotice( '' );
+		setParsedSQL( {
+			tableName: '',
+			tableColumns: [],
+			tableRows: [],
+		} );
+		setIsLoading( true );
 
-    // Parse SQL.
-    try {
-      setParsedSQL(
-        await apiFetch(
-          {
-            path: '/sql-to-cpt/v1/parse',
-            method: 'POST',
-            data: {
-              ...args
-            },
-          }
-        )
-      );
-      setIsLoading( false );
-    } catch ( { message } ) {
-      setIsLoading( false );
-      setSqlNotice( message );
-    }
-  };
+		// Parse SQL.
+		try {
+			setParsedSQL(
+				await apiFetch( {
+					path: '/sql-to-cpt/v1/parse',
+					method: 'POST',
+					data: {
+						...args,
+					},
+				} )
+			);
+			setIsLoading( false );
+		} catch ( { message } ) {
+			setIsLoading( false );
+			setSqlNotice( message );
+		}
+	};
 
-  /**
-   * Handle Import.
-   *
-   * This function is responsible for handling the
-   * import made by the user.
-   *
-   * @since 1.1.0
-   *
-   * @returns Promise<void>
-   */
-  const handleImport = async (): Promise<void> => {
-    setIsLoading( true );
+	/**
+	 * Handle Import.
+	 *
+	 * This function is responsible for handling the
+	 * import made by the user.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return Promise<void>
+	 */
+	const handleImport = async (): Promise< void > => {
+		setIsLoading( true );
 
-    // Import SQL.
-    try {
-      const url = await apiFetch(
-        {
-          path: '/sql-to-cpt/v1/import',
-          method: 'POST',
-          data: {
-            ...parsedSQL
-          },
-        }
-      );
-      if ( url ) {
-        window.location.href = `${url}`
-      }
-      setIsLoading( false );
-    } catch ( { message } ) {
-      setIsLoading( false );
-      setSqlNotice( message );
-    }
-  }
+		// Import SQL.
+		try {
+			const url = await apiFetch( {
+				path: '/sql-to-cpt/v1/import',
+				method: 'POST',
+				data: {
+					...parsedSQL,
+				},
+			} );
+			if ( url ) {
+				window.location.href = `${ url }`;
+			}
+			setIsLoading( false );
+		} catch ( { message } ) {
+			setIsLoading( false );
+			setSqlNotice( message );
+		}
+	};
 
-  return (
-    <>
-      {
-        parsedSQL.tableRows.length < 1 ? (
-          <Button
-            variant="primary"
-            onClick={ handleUpload }
-          >
-            { __( 'Upload SQL File', 'sql-to-cpt' ) }
-          </Button>
-        ) : (
-          <Button
-            variant="primary"
-            onClick={ handleImport }
-          >
-            { __( 'Convert to CPT', 'sql-to-cpt' ) }
-          </Button>
-        )
-      }
-    </>
-  );
-}
+	return (
+		<>
+			{ parsedSQL.tableRows.length < 1 ? (
+				<Button variant="primary" onClick={ handleUpload }>
+					{ __( 'Upload SQL File', 'sql-to-cpt' ) }
+				</Button>
+			) : (
+				<Button variant="primary" onClick={ handleImport }>
+					{ __( 'Convert to CPT', 'sql-to-cpt' ) }
+				</Button>
+			) }
+		</>
+	);
+};
 
 export default ImportButton;

--- a/src/components/Notice.tsx
+++ b/src/components/Notice.tsx
@@ -1,5 +1,5 @@
 interface NoticeProps {
-  message: string;
+	message: string;
 }
 
 /**
@@ -10,13 +10,13 @@ interface NoticeProps {
  *
  * @since 1.0.0
  *
- * @param {Object} props - The component props.
+ * @param {Object}      props         - The component props.
  * @param {NoticeProps} props.message - Message to be displayed in notice.
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The Notice component.
  */
 const Notice = ( { message }: NoticeProps ): JSX.Element => {
-  return message && <nav>{ message }</nav>;
-}
+	return message && <nav>{ message }</nav>;
+};
 
 export default Notice;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from '@wordpress/element';
 
 interface ProgressBarProps {
-  isLoading: boolean;
+	isLoading: boolean;
 }
 
 /**
@@ -13,44 +13,42 @@ interface ProgressBarProps {
  * @since 1.2.0
  * @since 1.3.0 Implement Interval logic.
  *
- * @param {Object} props - The component props.
+ * @param {Object}           props           - The component props.
  * @param {ProgressBarProps} props.isLoading - True|False.
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The Progress Bar component.
  */
 const ProgressBar = ( { isLoading }: ProgressBarProps ): JSX.Element => {
-  const [ progress, setProgress ] = useState<number>( 0 );
+	const [ progress, setProgress ] = useState< number >( 0 );
 
-  useEffect( () => {
-    let progressInterval: string | number | NodeJS.Timeout;
+	useEffect( () => {
+		let progressInterval: string | number | NodeJS.Timeout;
 
-    if ( isLoading ) {
-      setProgress( 0 );
-      progressInterval = setInterval( () => {
-        setProgress( ( prev ) => ( prev < 90 ? prev + 10 : prev ) );
-      }, 500 );
-    } else {
-      setProgress( 0 );
-      clearInterval( progressInterval );
-    }
+		if ( isLoading ) {
+			setProgress( 0 );
+			progressInterval = setInterval( () => {
+				setProgress( ( prev ) => ( prev < 90 ? prev + 10 : prev ) );
+			}, 500 );
+		} else {
+			setProgress( 0 );
+			clearInterval( progressInterval );
+		}
 
-    return () => clearInterval( progressInterval );
-  }, [ isLoading ] );
+		return () => clearInterval( progressInterval );
+	}, [ isLoading ] );
 
-  return (
-    <>
-      {
-        isLoading && (
-          <div className="sqlt-cpt-progress-bar" role="progressbar">
-            <div>
-              <div style={{ width: `${progress}%` }} />
-            </div>
-            <p>{ progress }%</p>
-          </div>
-        )
-      }
-    </>
-  );
-}
+	return (
+		<>
+			{ isLoading && (
+				<div className="sqlt-cpt-progress-bar" role="progressbar">
+					<div>
+						<div style={ { width: `${ progress }%` } } />
+					</div>
+					<p>{ progress }%</p>
+				</div>
+			) }
+		</>
+	);
+};
 
 export default ProgressBar;

--- a/src/components/Purge.tsx
+++ b/src/components/Purge.tsx
@@ -4,8 +4,8 @@ import { Button } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 
 interface PurgeProps {
-  setIsLoading: Function;
-  setSqlNotice: Function;
+	setIsLoading: Function;
+	setSqlNotice: Function;
 }
 
 /**
@@ -16,58 +16,51 @@ interface PurgeProps {
  *
  * @since 1.3.0
  *
- * @param {Object} props - The component props.
+ * @param {Object}   props              - The component props.
  * @param {Function} props.setIsLoading - Function to set the loading state.
  * @param {Function} props.setSqlNotice - Function to set an SQL notice.
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The Purge component.
  */
 const Purge = ( { setIsLoading, setSqlNotice }: PurgeProps ): JSX.Element => {
-  const [ postType, setPostType ] = useState( '' );
+	const [ postType, setPostType ] = useState( '' );
 
-  const handlePurge = async () => {
-    setIsLoading( true );
+	const handlePurge = async () => {
+		setIsLoading( true );
 
-    try {
-      await apiFetch(
-        {
-          path: '/sql-to-cpt/v1/purge',
-          method: 'POST',
-          data: {
-            postType
-          },
-        }
-      );
-      setIsLoading( false );
-      window.location.reload();
-    } catch ( { message } ) {
-      setIsLoading( false );
-      setSqlNotice( message );
-    }
-  }
+		try {
+			await apiFetch( {
+				path: '/sql-to-cpt/v1/purge',
+				method: 'POST',
+				data: {
+					postType,
+				},
+			} );
+			setIsLoading( false );
+			window.location.reload();
+		} catch ( { message } ) {
+			setIsLoading( false );
+			setSqlNotice( message );
+		}
+	};
 
-  return (
-    <div className="sqlt-purge">
-      <select
-        onChange={ ( e ) => { setPostType( e.target.value ) } }
-      >
-        <option>Select CPT</option>
-        {
-          sqlt.postTypes.map( ( item: string ) => {
-            return (
-              <option>{ item }</option>
-            )
-          } )
-        }
-      </select>
-      <Button
-        variant="tertiary"
-        onClick={ handlePurge }
-      >
-        { __( 'Purge CPT', 'sql-to-cpt' ) }
-      </Button>
-    </div>
-  );
-}
+	return (
+		<div className="sqlt-purge">
+			<select
+				onChange={ ( e ) => {
+					setPostType( e.target.value );
+				} }
+			>
+				<option>Select CPT</option>
+				{ sqlt.postTypes.map( ( item: string, index: number ) => {
+					return <option key={ index }>{ item }</option>;
+				} ) }
+			</select>
+			<Button variant="tertiary" onClick={ handlePurge }>
+				{ __( 'Purge CPT', 'sql-to-cpt' ) }
+			</Button>
+		</div>
+	);
+};
 
 export default Purge;

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -3,11 +3,11 @@ import { __ } from '@wordpress/i18n';
 import Disabled from './Disabled';
 
 interface ParsedSQLProps {
-  parsedSQL: {
-    tableName: string;
-    tableRows: any[];
-    tableColumns: string[];
-  }
+	parsedSQL: {
+		tableName: string;
+		tableRows: any[];
+		tableColumns: string[];
+	};
 }
 
 /**
@@ -18,30 +18,26 @@ interface ParsedSQLProps {
  *
  * @since 1.2.0
  *
- * @param {Object} props - The component props.
+ * @param {Object}         props           - The component props.
  * @param {ParsedSQLProps} props.parsedSQL - The parsed SQL object.
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The Table Columns component.
  */
 const TableColumns = ( { parsedSQL }: ParsedSQLProps ): JSX.Element => {
-  return (
-    <>
-      {
-        parsedSQL.tableColumns.length > 0 && (
-          <div className="sqlt-cpt-table-columns" role="list">
-            <h3>{ __( 'Columns', 'sql-to-cpt' ) }</h3>
-            {
-              parsedSQL.tableColumns.map( ( name: string, index: number ) => {
-                return (
-                  <Disabled key={ index } name={ name } />
-                )
-              } )
-            }
-          </div>
-        )
-      }
-    </>
-  );
-}
+	return (
+		<>
+			{ parsedSQL.tableColumns.length > 0 && (
+				<div className="sqlt-cpt-table-columns" role="list">
+					<h3>{ __( 'Columns', 'sql-to-cpt' ) }</h3>
+					{ parsedSQL.tableColumns.map(
+						( name: string, index: number ) => {
+							return <Disabled key={ index } name={ name } />;
+						}
+					) }
+				</div>
+			) }
+		</>
+	);
+};
 
 export default TableColumns;

--- a/src/components/TableName.tsx
+++ b/src/components/TableName.tsx
@@ -3,11 +3,11 @@ import { __ } from '@wordpress/i18n';
 import Disabled from './Disabled';
 
 interface ParsedSQLProps {
-  parsedSQL: {
-    tableName: string;
-    tableRows: any[];
-    tableColumns: string[];
-  }
+	parsedSQL: {
+		tableName: string;
+		tableRows: any[];
+		tableColumns: string[];
+	};
 }
 
 /**
@@ -18,26 +18,22 @@ interface ParsedSQLProps {
  *
  * @since 1.2.0
  *
- * @param {Object} props - The component props.
+ * @param {Object}         props           - The component props.
  * @param {ParsedSQLProps} props.parsedSQL - The parsed SQL object.
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The Table Name component.
  */
 const TableName = ( { parsedSQL }: ParsedSQLProps ): JSX.Element => {
-  return (
-    <>
-      {
-        parsedSQL.tableName && (
-          <div className="sqlt-cpt-table-name" role="list">
-            <h3>{ __( 'Table', 'sql-to-cpt' ) }</h3>
-            <Disabled
-              name={ parsedSQL.tableName }
-            />
-          </div>
-        )
-      }
-    </>
-  );
-}
+	return (
+		<>
+			{ parsedSQL.tableName && (
+				<div className="sqlt-cpt-table-name" role="list">
+					<h3>{ __( 'Table', 'sql-to-cpt' ) }</h3>
+					<Disabled name={ parsedSQL.tableName } />
+				</div>
+			) }
+		</>
+	);
+};
 
 export default TableName;

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,5 +1,5 @@
 interface TextInputProps {
-  name: string;
+	name: string;
 }
 
 /**
@@ -10,17 +10,17 @@ interface TextInputProps {
  *
  * @since 1.0.0
  *
- * @param {Object} props - The component props.
+ * @param {Object}         props      - The component props.
  * @param {TextInputProps} props.name - Default Text value.
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} The TextInput component.
  */
 const TextInput = ( { name }: TextInputProps ): JSX.Element => {
-  return (
-    <p>
-      <input type="text" defaultValue={ name } />
-    </p>
-  );
-}
+	return (
+		<p>
+			<input type="text" defaultValue={ name } />
+		</p>
+	);
+};
 
 export default TextInput;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,15 @@
-import { getRoot } from './utils'
+import { getRoot } from './utils';
 import { createRoot } from 'react-dom/client';
 
 import App from './app/App';
 
 const run = async () => {
-  try {
-    const root = await getRoot('sql-to-cpt');
-    createRoot(root).render(<App />);
-  } catch (e) {
-    throw new Error(e);
-  }
-}
+	try {
+		const root = await getRoot( 'sql-to-cpt' );
+		createRoot( root ).render( <App /> );
+	} catch ( e ) {
+		throw new Error( e );
+	}
+};
 
 run();

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -9,29 +9,29 @@ import { __ } from '@wordpress/i18n';
  * @since 1.0.0
  *
  * @param {string} id HTML Element Id.
- * @returns Promise<HTMLElement>
+ * @return Promise<HTMLElement>
  */
-export const getRoot = (id: string): Promise<HTMLElement> => {
-  let elapsedTime = 0;
-  let interval = 25;
+export const getRoot = ( id: string ): Promise< HTMLElement > => {
+	let elapsedTime = 0;
+	const interval = 25;
 
-  return new Promise((resolve, reject) => {
-    const intervalId = setInterval(() => {
-      elapsedTime += interval;
-      const root = document.getElementById(id);
+	return new Promise( ( resolve, reject ) => {
+		const intervalId = setInterval( () => {
+			elapsedTime += interval;
+			const root = document.getElementById( id );
 
-      if (root) {
-        clearInterval(intervalId)
-        resolve(root as HTMLElement);
-      }
+			if ( root ) {
+				clearInterval( intervalId );
+				resolve( root as HTMLElement );
+			}
 
-      if (elapsedTime > (10 * interval)) {
-        clearInterval(intervalId)
-        reject(new Error('Unable to get root container...'));
-      }
-    }, interval);
-  });
-}
+			if ( elapsedTime > 10 * interval ) {
+				clearInterval( intervalId );
+				reject( new Error( 'Unable to get root container...' ) );
+			}
+		}, interval );
+	} );
+};
 
 /**
  * Get Modal Params.
@@ -42,14 +42,14 @@ export const getRoot = (id: string): Promise<HTMLElement> => {
  *
  * @since 1.0.0
  *
- * @returns {Object} Modal Params.
+ * @return {Object} Modal Params.
  */
 export const getModalParams = () => {
-  return {
-    title: __( 'Select SQL File', 'sql-to-cpt' ),
-    button: {
-      text: __( 'Use SQL', 'sql-to-cpt' )
-    },
-    multiple: false,
-  };
-}
+	return {
+		title: __( 'Select SQL File', 'sql-to-cpt' ),
+		button: {
+			text: __( 'Use SQL', 'sql-to-cpt' ),
+		},
+		multiple: false,
+	};
+};

--- a/tests/js/Disabled.test.tsx
+++ b/tests/js/Disabled.test.tsx
@@ -5,19 +5,19 @@ import '@testing-library/jest-dom';
 import Disabled from '../../src/components/Disabled';
 
 describe( 'Disabled', () => {
-  it( 'renders the component with correct text', () => {
-    const { container } = render( <Disabled name="post_title" /> );
+	it( 'renders the component with correct text', () => {
+		const { container } = render( <Disabled name="post_title" /> );
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<p><input type="text" disabled="" value="post_title"></p>`
-    );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<p><input type="text" disabled="" value="post_title"></p>`
+		);
 
-    // Assert the input is rendered and is disabled.
-    const input = screen.getByRole( 'textbox' );
-    expect( input ).toBeDisabled();
-    expect( input ).toHaveValue( 'post_title' );
-    expect( input ).toBeInTheDocument();
-    expect( input ).toBeInstanceOf( HTMLInputElement );
-  } );
+		// Assert the input is rendered and is disabled.
+		const input = screen.getByRole( 'textbox' );
+		expect( input ).toBeDisabled();
+		expect( input ).toHaveValue( 'post_title' );
+		expect( input ).toBeInTheDocument();
+		expect( input ).toBeInstanceOf( HTMLInputElement );
+	} );
 } );

--- a/tests/js/ImportButton.test.tsx
+++ b/tests/js/ImportButton.test.tsx
@@ -5,19 +5,19 @@ import '@testing-library/jest-dom';
 import ImportButton from '../../src/components/ImportButton';
 
 jest.mock( '@wordpress/i18n', () => ( {
-  __: jest.fn( ( arg ) => arg )
+	__: jest.fn( ( arg ) => arg ),
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
-  Button: jest.fn( ( { children, variant, onClick } ) => {
-    return (
-      <>
-        <button className={ variant } onClick={ onClick }>
-          { children }
-        </button>
-      </>
-    )
-  } )
+	Button: jest.fn( ( { children, variant, onClick } ) => {
+		return (
+			<>
+				<button className={ variant } onClick={ onClick }>
+					{ children }
+				</button>
+			</>
+		);
+	} ),
 } ) );
 
 const setIsLoading = jest.fn();
@@ -25,67 +25,59 @@ const setSqlNotice = jest.fn();
 const setParsedSQL = jest.fn();
 
 describe( 'ImportButton', () => {
-  it( 'renders the button with "Upload SQL File" text', () => {
-    const parsedSQL = {
-      tableName: 'student',
-      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-      tableRows: [],
-    }
+	it( 'renders the button with "Upload SQL File" text', () => {
+		const parsedSQL = {
+			tableName: 'student',
+			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+			tableRows: [],
+		};
 
-    const { container } = render(
-      <ImportButton
-        parsedSQL={ parsedSQL }
-        setIsLoading={ setIsLoading }
-        setSqlNotice={ setSqlNotice }
-        setParsedSQL={ setParsedSQL }
-      />
-    );
+		const { container } = render(
+			<ImportButton
+				parsedSQL={ parsedSQL }
+				setIsLoading={ setIsLoading }
+				setSqlNotice={ setSqlNotice }
+				setParsedSQL={ setParsedSQL }
+			/>
+		);
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<button class="primary">Upload SQL File</button>`
-    );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<button class="primary">Upload SQL File</button>`
+		);
 
-    // Assert the button is displayed.
-    const uploadButton = screen.getByRole( 'button' );
-    expect( uploadButton ).toHaveClass( 'primary' );
-    expect( uploadButton ).toBeInTheDocument();
-    expect( uploadButton ).toBeInstanceOf( HTMLButtonElement );
-  } );
+		// Assert the button is displayed.
+		const uploadButton = screen.getByRole( 'button' );
+		expect( uploadButton ).toHaveClass( 'primary' );
+		expect( uploadButton ).toBeInTheDocument();
+		expect( uploadButton ).toBeInstanceOf( HTMLButtonElement );
+	} );
 
-  it( 'renders the button with "Convert to CPT" text', () => {
-    const parsedSQL = {
-      tableName: 'student',
-      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-      tableRows: [
-        [
-          1,
-          'John Doe',
-          37,
-          'M',
-          'john@doe.com'
-        ]
-      ]
-    }
+	it( 'renders the button with "Convert to CPT" text', () => {
+		const parsedSQL = {
+			tableName: 'student',
+			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+		};
 
-    const { container } = render(
-      <ImportButton
-        parsedSQL={ parsedSQL }
-        setIsLoading={ setIsLoading }
-        setSqlNotice={ setSqlNotice }
-        setParsedSQL={ setParsedSQL }
-      />
-    );
+		const { container } = render(
+			<ImportButton
+				parsedSQL={ parsedSQL }
+				setIsLoading={ setIsLoading }
+				setSqlNotice={ setSqlNotice }
+				setParsedSQL={ setParsedSQL }
+			/>
+		);
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<button class="primary">Convert to CPT</button>`
-    );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<button class="primary">Convert to CPT</button>`
+		);
 
-    // Assert the button is displayed.
-    const importButton = screen.getByRole( 'button' );
-    expect( importButton ).toHaveClass( 'primary' );
-    expect( importButton ).toBeInTheDocument();
-    expect( importButton ).toBeInstanceOf( HTMLButtonElement );
-  } );
+		// Assert the button is displayed.
+		const importButton = screen.getByRole( 'button' );
+		expect( importButton ).toHaveClass( 'primary' );
+		expect( importButton ).toBeInTheDocument();
+		expect( importButton ).toBeInstanceOf( HTMLButtonElement );
+	} );
 } );

--- a/tests/js/Notice.test.tsx
+++ b/tests/js/Notice.test.tsx
@@ -5,26 +5,30 @@ import '@testing-library/jest-dom';
 import Notice from '../../src/components/Notice';
 
 describe( 'Notice', () => {
-  it( 'renders the component with correct text', () => {
-    const { container } = render( <Notice message="Fatal Error! Wrong file type: sample-1.png" /> );
+	it( 'renders the component with correct text', () => {
+		const { container } = render(
+			<Notice message="Fatal Error! Wrong file type: sample-1.png" />
+		);
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<nav>Fatal Error! Wrong file type: sample-1.png</nav>`
-    );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<nav>Fatal Error! Wrong file type: sample-1.png</nav>`
+		);
 
-    // Assert the text content is rendered inside the nav element.
-    const nav = screen.getByText( 'Fatal Error! Wrong file type: sample-1.png' );
-    const navName = nav.tagName.toLowerCase();
-    expect( navName ).toBe( 'nav' );
-    expect( nav ).toBeInTheDocument();
-    expect( nav ).toBeInstanceOf( HTMLElement );
-  } );
+		// Assert the text content is rendered inside the nav element.
+		const nav = screen.getByText(
+			'Fatal Error! Wrong file type: sample-1.png'
+		);
+		const navName = nav.tagName.toLowerCase();
+		expect( navName ).toBe( 'nav' );
+		expect( nav ).toBeInTheDocument();
+		expect( nav ).toBeInstanceOf( HTMLElement );
+	} );
 
-  it( 'DOES NOT render the Notice', () => {
-    const { container } = render( <Notice message="" /> );
+	it( 'DOES NOT render the Notice', () => {
+		const { container } = render( <Notice message="" /> );
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe( `` );
-  } );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe( `` );
+	} );
 } );

--- a/tests/js/ProgressBar.test.tsx
+++ b/tests/js/ProgressBar.test.tsx
@@ -5,25 +5,27 @@ import '@testing-library/jest-dom';
 import ProgressBar from '../../src/components/ProgressBar';
 
 describe( 'ProgressBar', () => {
-  it( 'renders the Progress Bar', () => {
-    const { container } = render( <ProgressBar isLoading={true} /> );
+	it( 'renders the Progress Bar', () => {
+		const { container } = render( <ProgressBar isLoading={ true } /> );
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<div class="sqlt-cpt-progress-bar" role="progressbar"><div><div style="width: 0%;"></div></div><p>0%</p></div>`
-    );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<div class="sqlt-cpt-progress-bar" role="progressbar"><div><div style="width: 0%;"></div></div><p>0%</p></div>`
+		);
 
-    // Assert the ProgressBar is rendered and is disabled.
-    const progressBar = screen.getByRole( 'progressbar' );
-    expect( progressBar ).toBeInTheDocument();
-    expect( progressBar ).toBeInstanceOf( HTMLDivElement );
-    expect( progressBar ).toContainHTML( '<div><div style="width: 0%;"></div></div><p>0%</p>' );
-  } );
+		// Assert the ProgressBar is rendered and is disabled.
+		const progressBar = screen.getByRole( 'progressbar' );
+		expect( progressBar ).toBeInTheDocument();
+		expect( progressBar ).toBeInstanceOf( HTMLDivElement );
+		expect( progressBar ).toContainHTML(
+			'<div><div style="width: 0%;"></div></div><p>0%</p>'
+		);
+	} );
 
-  it( 'DOES NOT render the Progress Bar', () => {
-    const { container } = render( <ProgressBar isLoading={false} /> );
+	it( 'DOES NOT render the Progress Bar', () => {
+		const { container } = render( <ProgressBar isLoading={ false } /> );
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe( `` );
-  } );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe( `` );
+	} );
 } );

--- a/tests/js/TableColumns.test.tsx
+++ b/tests/js/TableColumns.test.tsx
@@ -5,58 +5,48 @@ import '@testing-library/jest-dom';
 import TableColumns from '../../src/components/TableColumns';
 
 jest.mock( '@wordpress/i18n', () => ( {
-  __: jest.fn( ( arg ) => arg )
+	__: jest.fn( ( arg ) => arg ),
 } ) );
 
 describe( 'TableColumns', () => {
-  it( 'renders the Table Columns', () => {
-    const parsedSQL = {
-      tableName: 'student',
-      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-      tableRows: [
-        [
-          1,
-          'John Doe',
-          37,
-          'M',
-          'john@doe.com'
-        ]
-      ]
-    }
+	it( 'renders the Table Columns', () => {
+		const parsedSQL = {
+			tableName: 'student',
+			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+		};
 
-    const { container } = render( <TableColumns parsedSQL={ parsedSQL } /> );
+		const { container } = render(
+			<TableColumns parsedSQL={ parsedSQL } />
+		);
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<div class="sqlt-cpt-table-columns" role="list"><h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p></div>`
-    );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<div class="sqlt-cpt-table-columns" role="list"><h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p></div>`
+		);
 
-    // Assert the Table Columns are displayed.
-    const tableColumns = screen.getByRole( 'list' );
-    expect( tableColumns ).toHaveClass( 'sqlt-cpt-table-columns' );
-    expect( tableColumns ).toBeInTheDocument();
-    expect( tableColumns ).toBeInstanceOf( HTMLDivElement );
-    expect( tableColumns ).toContainHTML( '<h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p>' );
-  } );
+		// Assert the Table Columns are displayed.
+		const tableColumns = screen.getByRole( 'list' );
+		expect( tableColumns ).toHaveClass( 'sqlt-cpt-table-columns' );
+		expect( tableColumns ).toBeInTheDocument();
+		expect( tableColumns ).toBeInstanceOf( HTMLDivElement );
+		expect( tableColumns ).toContainHTML(
+			'<h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p>'
+		);
+	} );
 
-  it( 'DOES NOT render the Table Columns', () => {
-    const parsedSQL = {
-      tableName: 'student',
-      tableColumns: [],
-      tableRows: [
-        [
-          1,
-          'John Doe',
-          37,
-          'M',
-          'john@doe.com'
-        ]
-      ]
-    }
+	it( 'DOES NOT render the Table Columns', () => {
+		const parsedSQL = {
+			tableName: 'student',
+			tableColumns: [],
+			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+		};
 
-    const { container } = render( <TableColumns parsedSQL={ parsedSQL } /> );
+		const { container } = render(
+			<TableColumns parsedSQL={ parsedSQL } />
+		);
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe( `` );
-  } );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe( `` );
+	} );
 } );

--- a/tests/js/TableName.test.tsx
+++ b/tests/js/TableName.test.tsx
@@ -5,57 +5,41 @@ import '@testing-library/jest-dom';
 import TableName from '../../src/components/TableName';
 
 jest.mock( '@wordpress/i18n', () => ( {
-  __: jest.fn( ( arg ) => arg )
+	__: jest.fn( ( arg ) => arg ),
 } ) );
 
 describe( 'TableName', () => {
-  it( 'renders the Table Name and its input', () => {
-    const parsedSQL = {
-      tableName: 'student',
-      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-      tableRows: [
-        [
-          1,
-          'John Doe',
-          37,
-          'M',
-          'john@doe.com'
-        ]
-      ]
-    }
+	it( 'renders the Table Name and its input', () => {
+		const parsedSQL = {
+			tableName: 'student',
+			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+		};
 
-    const { container } = render( <TableName parsedSQL={ parsedSQL } /> );
+		const { container } = render( <TableName parsedSQL={ parsedSQL } /> );
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<div class="sqlt-cpt-table-name" role="list"><h3>Table</h3><p><input type="text" disabled="" value="student"></p></div>`
-    );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<div class="sqlt-cpt-table-name" role="list"><h3>Table</h3><p><input type="text" disabled="" value="student"></p></div>`
+		);
 
-    // Assert the Table Name is displayed.
-    const tableName = screen.getByRole( 'list' );
-    expect( tableName ).toHaveClass( 'sqlt-cpt-table-name' );
-    expect( tableName ).toBeInTheDocument();
-    expect( tableName ).toBeInstanceOf( HTMLDivElement );
-  } );
+		// Assert the Table Name is displayed.
+		const tableName = screen.getByRole( 'list' );
+		expect( tableName ).toHaveClass( 'sqlt-cpt-table-name' );
+		expect( tableName ).toBeInTheDocument();
+		expect( tableName ).toBeInstanceOf( HTMLDivElement );
+	} );
 
-  it( 'DOES NOT render the Table Name', () => {
-    const parsedSQL = {
-      tableName: '',
-      tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-      tableRows: [
-        [
-          1,
-          'John Doe',
-          37,
-          'M',
-          'john@doe.com'
-        ]
-      ]
-    }
+	it( 'DOES NOT render the Table Name', () => {
+		const parsedSQL = {
+			tableName: '',
+			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+		};
 
-    const { container } = render( <TableName parsedSQL={ parsedSQL } /> );
+		const { container } = render( <TableName parsedSQL={ parsedSQL } /> );
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe( `` );
-  } );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe( `` );
+	} );
 } );

--- a/tests/js/TextInput.test.tsx
+++ b/tests/js/TextInput.test.tsx
@@ -5,18 +5,18 @@ import '@testing-library/jest-dom';
 import TextInput from '../../src/components/TextInput';
 
 describe( 'TextInput', () => {
-  it( 'renders the component with correct text', () => {
-    const { container } = render( <TextInput name="post_title" /> );
+	it( 'renders the component with correct text', () => {
+		const { container } = render( <TextInput name="post_title" /> );
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<p><input type="text" value="post_title"></p>`
-    );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<p><input type="text" value="post_title"></p>`
+		);
 
-    // Assert the input is rendered and is disabled.
-    const input = screen.getByRole( 'textbox' );
-    expect( input ).toHaveValue( 'post_title' );
-    expect( input ).toBeInTheDocument();
-    expect( input ).toBeInstanceOf( HTMLInputElement );
-  } );
+		// Assert the input is rendered and is disabled.
+		const input = screen.getByRole( 'textbox' );
+		expect( input ).toHaveValue( 'post_title' );
+		expect( input ).toBeInTheDocument();
+		expect( input ).toBeInstanceOf( HTMLInputElement );
+	} );
 } );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,64 +1,68 @@
-const path = require('path');
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const path = require( 'path' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 module.exports = {
-  ...defaultConfig,
+	...defaultConfig,
 
-  entry: {
-    app: './src/index.tsx',
-  },
+	entry: {
+		app: './src/index.tsx',
+	},
 
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js',
-  },
+	output: {
+		path: path.resolve( __dirname, 'dist' ),
+		filename: '[name].js',
+	},
 
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-  },
+	resolve: {
+		extensions: [ '.tsx', '.ts', '.js' ],
+	},
 
-  module: {
-    rules: [
-      {
-        test: /\.ts(x)?$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'ts-loader',
-          options: {
-            configFile: 'tsconfig.json',
-            transpileOnly: true
-          }
-        },
-      },
-      {
-        test: /\.js$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-          },
-        },
-      },
-      {
-        test: /\.(png|jpg|jpeg|gif|svg)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]',
-              outputPath: 'images/',
-            },
-          },
-        ],
-      },
-      {
-        test: /\.scss$/,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
-      },
-    ],
-  },
+	module: {
+		rules: [
+			{
+				test: /\.ts(x)?$/,
+				exclude: /(node_modules|bower_components)/,
+				use: {
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.json',
+						transpileOnly: true,
+					},
+				},
+			},
+			{
+				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-env',
+							'@babel/preset-react',
+							'@babel/preset-typescript',
+						],
+					},
+				},
+			},
+			{
+				test: /\.(png|jpg|jpeg|gif|svg)$/,
+				use: [
+					{
+						loader: 'file-loader',
+						options: {
+							name: '[name].[ext]',
+							outputPath: 'images/',
+						},
+					},
+				],
+			},
+			{
+				test: /\.scss$/,
+				use: [ 'style-loader', 'css-loader', 'sass-loader' ],
+			},
+		],
+	},
 
-  devtool: 'source-map',
-  mode: 'production'
+	devtool: 'source-map',
+	mode: 'production',
 };


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/25).

## Description / Background Context

Similar to [43](https://github.com/badasswp/search-and-replace/pull/44), there is a need to enforce WP style linting across the codebase to ensure consistency among PRs. Once done, Contributors should be able to lint and perform fixes easily like so:

```js
yarn lint:js:fix
```

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn build`.
3. Now run `yarn lint:js:fix` to correctly lint your JS files.
4. All other features should work correctly as before.