### PR TITLE
Add Local dev env setup for WP

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -2,6 +2,7 @@
 .editorconfig
 .gitignore
 .github
+.wp-env.json
 CHANGELOG.md
 jest.config.js
 jest.setup.js
@@ -14,3 +15,4 @@ phpstan.neon
 src
 assets
 tests
+bin

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,16 @@
+{
+	"plugins": [
+		"."
+	],
+	"phpVersion": "8.2",
+	"port": 5467,
+	"testsPort": 5468,
+	"config": {
+    "ALLOW_UNFILTERED_UPLOADS": true,
+		"WP_SITEURL": "http://sql.localhost",
+		"WP_HOME": "http://sql.localhost"
+	},
+	"lifecycleScripts": {
+		"afterStart": "./bin/setup.sh"
+	}
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.1
 * Enforce WP linting style across plugin.
+* Feat: Add WP local dev env for contributors.
 
 ## 1.3.0
 * Fix: Ensure REST response on SQL Import.

--- a/README.md
+++ b/README.md
@@ -142,3 +142,33 @@ public function custom_options( $options ): array {
 
 - options _`{mixed[]}`_ By default this will be an array containing the post options of the CPT.
 <br/>
+
+---
+
+## Contribute
+
+Contributions are __welcome__ and will be fully __credited__. To contribute, please fork this repo and raise a PR (Pull Request) against the `master` branch.
+
+### Pre-requisites
+
+You should have the following tools before proceeding to the next steps:
+
+- Composer
+- Yarn
+- Docker
+
+To enable you start development, please run:
+
+```bash
+yarn start
+```
+
+This should spin up a local WP env instance for you to work with at:
+
+```bash
+http://sql.localhost:5467
+```
+
+You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please username as `admin` & password as `password`.
+
+__Awesome!__ - Thanks for being interested in contributing your time and code to this project!

--- a/README.md
+++ b/README.md
@@ -169,6 +169,5 @@ This should spin up a local WP env instance for you to work with at:
 http://sql.localhost:5467
 ```
 
-You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please username as `admin` & password as `password`.
-
+You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please log in as `admin` & password as `password`.
 __Awesome!__ - Thanks for being interested in contributing your time and code to this project!

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+wp-env run cli wp theme activate twentytwentythree
+wp-env run cli wp rewrite structure /%postname%

--- a/package.json
+++ b/package.json
@@ -6,11 +6,21 @@
   "license": "GPL-2.0-or-later",
   "homepage": "https://github.com/badasswp/sql-to-cpt#readme",
   "scripts": {
-    "start": "npm install && composer install",
-    "dev": "webpack --watch",
+    "start": "yarn boot && yarn build && yarn wp-env start",
+    "stop": "yarn wp-env stop",
+    "watch": "webpack --watch",
     "build": "webpack",
+    "boot": "composer install && yarn install",
     "test": "npm-run-all --parallel test:*",
-    "test:js": "jest --passWithNoTests"
+    "test:js": "jest --passWithNoTests",
+    "test:php": "composer run test",
+    "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:js:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "lint:php": "composer run lint",
+    "lint:php:fix": "composer run lint:fix",
+    "ci": "yarn test:js && yarn lint:js && yarn test:php && yarn lint:php",
+    "wp-env": "wp-env",
+    "bash": "wp-env run cli bash"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",
@@ -21,6 +31,7 @@
     "@testing-library/jest-dom": "5.17",
     "@testing-library/react": "15.0.6",
     "@types/jest": "^29.5.4",
+    "@wordpress/env": "^10.20.0",
     "@wordpress/eslint-plugin": "^15.0.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@testing-library/react": "15.0.6",
     "@types/jest": "^29.5.4",
     "@wordpress/env": "^10.20.0",
-    "@wordpress/eslint-plugin": "^15.0.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 = 1.3.1 =
 * Enforce WP linting style across plugin.
+* Feat: Add WP local dev env for contributors.
 
 = 1.3.0 =
 * Fix: Ensure REST response on SQL Import.


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues27).

## Description / Background Context

At the moment, contributors have to use their own methods of setting up this repo. We need to provide a consistent way for users to spin up this project's repo and contribute quickly perhaps using WP's `wp-env` so that users can now spin up their local instance by running:

```bash
yarn wp-env start
```

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. The repo should now build and boot up the `wp-env` instance ready for the user.
4. User should be able to access the site at: `http://sql.localhost:5467`