### PR TITLE
Chore: Lint files correctly

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,7 +6,7 @@
 	"port": 5467,
 	"testsPort": 5468,
 	"config": {
-    "ALLOW_UNFILTERED_UPLOADS": true,
+		"ALLOW_UNFILTERED_UPLOADS": true,
 		"WP_SITEURL": "http://sql.localhost",
 		"WP_HOME": "http://sql.localhost"
 	},

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,3 +2,5 @@
 
 wp-env run cli wp theme activate twentytwentythree
 wp-env run cli wp rewrite structure /%postname%
+wp-env run cli wp option update blogname "SQL to CPT"
+wp-env run cli wp option update blogdescription "Import & Convert SQL files to Custom Post Types (CPT)."


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/sql-to-cpt/issues/30).

## Description / Background Context

A small linting issue was addressed in this PR as well as updating the `setup.sh` bash script.

## Testing Instructions

1. Pull PR to local.
2. Now run `yarn boot` to correctly lint your JS files.
3. WP Instance should now have a custom blog title and description.