### PR TITLE
Refactor: Use webpack generated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+* Refactor: Used webpack generated dependencies.
+
 ## 1.3.4
 * Specify `wordpress-plugin` as Composer package type.
 * Tested up to WP 6.9.

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -42,13 +42,13 @@ class Boot extends Service implements Kernel {
 			return;
 		}
 
-		$asset_file = require_once dirname( __DIR__, 2 ) . '/dist/app.asset.php';
+		$assets = $this->get_assets( plugin_dir_path( __FILE__ ) . '/../../dist/app.asset.php' );
 
 		wp_enqueue_script(
 			'sql-to-cpt',
 			trailingslashit( plugin_dir_url( __FILE__ ) ) . '../../dist/app.js',
-			$asset_file['dependencies'],
-			$asset_file['version'],
+			$assets['dependencies'],
+			$assets['version'],
 			false,
 		);
 
@@ -103,5 +103,36 @@ class Boot extends Service implements Kernel {
 			],
 			$mimes
 		);
+	}
+
+	/**
+	 * Get Asset dependencies.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string $path Path to webpack generated PHP asset file.
+	 * @return array
+	 */
+	protected function get_assets( string $path ): array {
+		$assets = [
+			'version'      => 'ec9080196954ae49fb68',
+			'dependencies' => [
+				'react',
+				'react-dom',
+				'wp-api-fetch',
+				'wp-components',
+				'wp-element',
+				'wp-i18n',
+			],
+		];
+
+		if ( ! file_exists( $path ) ) {
+			return $assets;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
+		$assets = require_once $path;
+
+		return $assets;
 	}
 }

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -42,7 +42,7 @@ class Boot extends Service implements Kernel {
 			return;
 		}
 
-		$asset_file = require_once dirname(__DIR__, 2) . '/dist/app.asset.php';
+		$asset_file = require_once dirname( __DIR__, 2 ) . '/dist/app.asset.php';
 
 		wp_enqueue_script(
 			'sql-to-cpt',

--- a/inc/Services/Boot.php
+++ b/inc/Services/Boot.php
@@ -42,22 +42,13 @@ class Boot extends Service implements Kernel {
 			return;
 		}
 
-		// Load Script.
+		$asset_file = require_once dirname(__DIR__, 2) . '/dist/app.asset.php';
+
 		wp_enqueue_script(
 			'sql-to-cpt',
 			trailingslashit( plugin_dir_url( __FILE__ ) ) . '../../dist/app.js',
-			[
-				'wp-i18n',
-				'wp-element',
-				'wp-blocks',
-				'wp-components',
-				'wp-editor',
-				'wp-hooks',
-				'wp-compose',
-				'wp-plugins',
-				'wp-edit-post',
-			],
-			'1.2.0',
+			$asset_file['dependencies'],
+			$asset_file['version'],
 			false,
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.4.0
+* Refactor: Used webpack generated dependencies.
+
 = 1.3.4
 * Specify `wordpress-plugin` as Composer package type.
 * Tested up to WP 6.9.

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -105,17 +105,14 @@ class BootTest extends TestCase {
 				'sql-to-cpt',
 				'https://example.com/wp-content/plugins/sql-to-cpt/inc/Services/Boot.php/../../dist/app.js',
 				[
-					'wp-i18n',
-					'wp-element',
-					'wp-blocks',
+					'react',
+					'react-dom',
+					'wp-api-fetch',
 					'wp-components',
-					'wp-editor',
-					'wp-hooks',
-					'wp-compose',
-					'wp-plugins',
-					'wp-edit-post',
+					'wp-element',
+					'wp-i18n'
 				],
-				'1.2.0',
+				'ec9080196954ae49fb68',
 				false,
 			);
 

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -83,6 +83,24 @@ class BootTest extends TestCase {
 
 		$boot = new \ReflectionClass( Boot::class );
 
+		$mock_boot = Mockery::mock( Boot::class )->makePartial();
+		$mock_boot->shouldAllowMockingProtectedMethods();
+
+		$mock_boot->shouldReceive( 'get_assets' )
+			->andReturn(
+				[
+					'dependencies' => [
+						'react',
+						'react-dom',
+						'wp-api-fetch',
+						'wp-components',
+						'wp-element',
+						'wp-i18n',
+					],
+					'version'      => 'ec9080196954ae49fb68',
+				]
+			);
+
 		\WP_Mock::userFunction( 'plugin_dir_url' )
 			->with( $boot->getFileName() )
 			->andReturn( 'https://example.com/wp-content/plugins/sql-to-cpt/inc/Services/Boot.php' );

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -5,7 +5,6 @@ namespace SqlToCpt\Tests\Services;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Services\Boot;
-use SqlToCpt\Abstracts\Service;
 
 /**
  * @covers \SqlToCpt\Services\Boot::register

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -110,7 +110,7 @@ class BootTest extends TestCase {
 					'wp-api-fetch',
 					'wp-components',
 					'wp-element',
-					'wp-i18n'
+					'wp-i18n',
 				],
 				'ec9080196954ae49fb68',
 				false,

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -12,6 +12,7 @@ use SqlToCpt\Abstracts\Service;
  * @covers \SqlToCpt\Services\Boot::register_translation
  * @covers \SqlToCpt\Services\Boot::register_mimes
  * @covers \SqlToCpt\Services\Boot::register_scripts
+ * @covers \SqlToCpt\Services\Boot::get_assets
  */
 class BootTest extends TestCase {
 	public Boot $boot;


### PR DESCRIPTION
This PR resolves [WP-44](https://appworld.atlassian.net/browse/WP-44)

## Description / Background Context

Implementing webpack generated dependencies.

## Testing Instructions

- Pull PR to local.
- Then proceed to the plugin page.
- Upload a `.sql` file and convert to `cpt`.
- Observe that there was no error and the `cpt` was created successfully.

## Screenshots / Screencast


<img width="283" height="137" alt="Screenshot 2026-04-09 104555" src="https://github.com/user-attachments/assets/2ec20b6b-04a1-41c0-8eec-a807710201bb" />



