### PR TITLE
Refactor: Replace fully qualified path classes with their counter part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Refactor: Replaced hard coded HTTP verbs with `WP_REST_Server` constant.
 * Refactor: Simplified register mimes.
 * Refactor: Used webpack generated dependencies.
+* Refactor: Replaced fully qualified path classes with their `use` counter part
 
 ## 1.3.4
 * Specify `wordpress-plugin` as Composer package type.

--- a/inc/Abstracts/Route.php
+++ b/inc/Abstracts/Route.php
@@ -10,6 +10,8 @@
 
 namespace SqlToCpt\Abstracts;
 
+use WP_Error;
+use WP_REST_Request;
 use SqlToCpt\Interfaces\Router;
 
 /**
@@ -39,9 +41,9 @@ abstract class Route implements Router {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @var \WP_REST_Request
+	 * @var WP_REST_Request
 	 */
-	public \WP_REST_Request $request;
+	public WP_REST_Request $request;
 
 	/**
 	 * Response Callback.
@@ -51,7 +53,7 @@ abstract class Route implements Router {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return \WP_REST_Response|\WP_Error
+	 * @return \WP_REST_Response|WP_Error
 	 */
 	abstract public function response();
 
@@ -64,8 +66,8 @@ abstract class Route implements Router {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param \WP_REST_Request $request Request object.
-	 * @return \WP_REST_Response|\WP_Error
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function request( $request ) {
 		$this->request = $request;
@@ -101,12 +103,12 @@ abstract class Route implements Router {
 	 * @since 1.0.0
 	 *
 	 * @param string $message Error Msg.
-	 * @return \WP_Error
+	 * @return WP_Error
 	 */
-	public function get_400_response( $message ): \WP_Error {
+	public function get_400_response( $message ): WP_Error {
 		$args = $this->request->get_json_params();
 
-		return new \WP_Error(
+		return new WP_Error(
 			'sql-to-cpt-bad-request',
 			sprintf(
 				'Fatal Error: Bad Request, %s',
@@ -124,14 +126,14 @@ abstract class Route implements Router {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param \WP_REST_Request $request Request Object.
-	 * @return bool|\WP_Error
+	 * @param WP_REST_Request $request Request Object.
+	 * @return bool|WP_Error
 	 */
 	public function is_user_permissible( $request ) {
 		$http_error = rest_authorization_required_code();
 
 		if ( ! current_user_can( 'administrator' ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'sql-to-cpt-rest-forbidden',
 				sprintf( 'Invalid User. Error: %s', $http_error ),
 				[ 'status' => $http_error ]
@@ -139,7 +141,7 @@ abstract class Route implements Router {
 		}
 
 		if ( ! wp_verify_nonce( $request->get_header( 'X-WP-Nonce' ), 'wp_rest' ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'sql-to-cpt-rest-forbidden',
 				sprintf( 'Invalid Nonce. Error: %s', $http_error ),
 				[ 'status' => $http_error ]

--- a/inc/Abstracts/Route.php
+++ b/inc/Abstracts/Route.php
@@ -41,7 +41,7 @@ abstract class Route implements Router {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @var WP_REST_Request
+	 * @var \WP_REST_Request
 	 */
 	public WP_REST_Request $request;
 
@@ -53,7 +53,7 @@ abstract class Route implements Router {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return \WP_REST_Response|WP_Error
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	abstract public function response();
 
@@ -66,8 +66,8 @@ abstract class Route implements Router {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return \WP_REST_Response|WP_Error
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function request( $request ) {
 		$this->request = $request;
@@ -103,7 +103,7 @@ abstract class Route implements Router {
 	 * @since 1.0.0
 	 *
 	 * @param string $message Error Msg.
-	 * @return WP_Error
+	 * @return \WP_Error
 	 */
 	public function get_400_response( $message ): WP_Error {
 		$args = $this->request->get_json_params();
@@ -126,8 +126,8 @@ abstract class Route implements Router {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param WP_REST_Request $request Request Object.
-	 * @return bool|WP_Error
+	 * @param \WP_REST_Request $request Request Object.
+	 * @return bool|\WP_Error
 	 */
 	public function is_user_permissible( $request ) {
 		$http_error = rest_authorization_required_code();

--- a/inc/Core/Parser.php
+++ b/inc/Core/Parser.php
@@ -10,6 +10,8 @@
 
 namespace SqlToCpt\Core;
 
+use Exception;
+
 class Parser {
 	/**
 	 * SQL.
@@ -35,7 +37,7 @@ class Parser {
 	 */
 	protected function get_sql_string(): string {
 		if ( ! file_exists( $this->sql ) ) {
-			throw new \Exception(
+			throw new Exception(
 				sprintf(
 					'Fatal Error: File does not exist: %s',
 					esc_url( $this->sql )

--- a/inc/Routes/Import.php
+++ b/inc/Routes/Import.php
@@ -10,6 +10,7 @@
 
 namespace SqlToCpt\Routes;
 
+use WP_REST_Request;
 use SqlToCpt\Abstracts\Route;
 use SqlToCpt\Interfaces\Router;
 
@@ -42,7 +43,7 @@ class Import extends Route implements Router {
 	 *
 	 * @var \WP_REST_Request
 	 */
-	public \WP_REST_Request $request;
+	public WP_REST_Request $request;
 
 	/**
 	 * JSON Params.

--- a/inc/Routes/Parse.php
+++ b/inc/Routes/Parse.php
@@ -10,6 +10,8 @@
 
 namespace SqlToCpt\Routes;
 
+use Exception;
+use WP_REST_Request;
 use SqlToCpt\Core\Parser;
 use SqlToCpt\Abstracts\Route;
 use SqlToCpt\Interfaces\Router;
@@ -43,7 +45,7 @@ class Parse extends Route implements Router {
 	 *
 	 * @var \WP_REST_Request
 	 */
-	public \WP_REST_Request $request;
+	public WP_REST_Request $request;
 
 	/**
 	 * JSON Params.
@@ -113,7 +115,7 @@ class Parse extends Route implements Router {
 	protected function get_response( Parser $parser ) {
 		try {
 			$response = $parser->get_parsed_sql( $this->file );
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$response = $this->get_400_response(
 				sprintf( 'Unable to parse SQL file: %s', $e->getMessage() )
 			);

--- a/inc/Routes/Purge.php
+++ b/inc/Routes/Purge.php
@@ -10,6 +10,7 @@
 
 namespace SqlToCpt\Routes;
 
+use WP_REST_Request;
 use SqlToCpt\Abstracts\Route;
 use SqlToCpt\Interfaces\Router;
 
@@ -42,7 +43,7 @@ class Purge extends Route implements Router {
 	 *
 	 * @var \WP_REST_Request
 	 */
-	public \WP_REST_Request $request;
+	public WP_REST_Request $request;
 
 	/**
 	 * JSON Params.

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Refactor: Replaced hard coded HTTP verbs with `WP_REST_Server` constant.
 * Refactor: Simplified register mimes.
 * Refactor: Used webpack generated dependencies.
+* Refactor: Replaced fully qualified path classes with their `use` counter part
 
 = 1.3.4
 * Specify `wordpress-plugin` as Composer package type.

--- a/tests/php/Abstracts/RouteTest.php
+++ b/tests/php/Abstracts/RouteTest.php
@@ -3,6 +3,9 @@
 namespace SqlToCpt\Tests\Abstracts;
 
 use Mockery;
+use WP_Error;
+use WP_Mock;
+use WP_REST_Request;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Abstracts\Route;
 
@@ -16,24 +19,24 @@ class RouteTest extends TestCase {
 	public Route $route;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->route = new ConcreteRoute();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_request_returns_response() {
-		$request  = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request  = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$response = $this->route->request( $request );
 
-		$this->assertInstanceOf( \WP_REST_Request::class, $response );
+		$this->assertInstanceOf( WP_REST_Request::class, $response );
 	}
 
 	public function test_register_route() {
-		\WP_Mock::userFunction( 'register_rest_route' )
+		WP_Mock::userFunction( 'register_rest_route' )
 			->with(
 				'sql-to-cpt/v1',
 				'test-register-route',
@@ -51,7 +54,7 @@ class RouteTest extends TestCase {
 	}
 
 	public function test_get_400_response() {
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -63,7 +66,7 @@ class RouteTest extends TestCase {
 
 		$this->route->request = $request;
 
-		$error = Mockery::mock( \WP_Error::class )->makePartial();
+		$error = Mockery::mock( WP_Error::class )->makePartial();
 		$error->shouldAllowMockingProtectedMethods();
 
 		$error->shouldReceive( '__construct' )
@@ -80,41 +83,41 @@ class RouteTest extends TestCase {
 
 		$error_response = $this->route->get_400_response( 'Something went terribly wrong...' );
 
-		$this->assertInstanceOf( \WP_Error::class, $error_response );
+		$this->assertInstanceOf( WP_Error::class, $error_response );
 		$this->assertConditionsMet();
 	}
 
 	public function test_is_user_permissible_returns_error_if_not_administrator() {
-		\WP_Mock::userFunction( 'rest_authorization_required_code' )
+		WP_Mock::userFunction( 'rest_authorization_required_code' )
 			->andReturn( 403 );
 
-		\WP_Mock::userFunction( 'current_user_can' )
+		WP_Mock::userFunction( 'current_user_can' )
 			->with( 'administrator' )
 			->andReturn( false );
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$this->assertInstanceOf(
-			\WP_Error::class,
+			WP_Error::class,
 			$this->route->is_user_permissible( $request )
 		);
 		$this->assertConditionsMet();
 	}
 
 	public function test_is_user_permissible_returns_error_if_nonce_fails() {
-		\WP_Mock::userFunction( 'rest_authorization_required_code' )
+		WP_Mock::userFunction( 'rest_authorization_required_code' )
 			->andReturn( 403 );
 
-		\WP_Mock::userFunction( 'current_user_can' )
+		WP_Mock::userFunction( 'current_user_can' )
 			->with( 'administrator' )
 			->andReturn( true );
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->with( 'a8ceg59jeqwvk', 'wp_rest' )
 			->andReturn( false );
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_header' )
@@ -122,28 +125,28 @@ class RouteTest extends TestCase {
 			->andReturn( 'a8ceg59jeqwvk' );
 
 		$this->assertInstanceOf(
-			\WP_Error::class,
+			WP_Error::class,
 			$this->route->is_user_permissible( $request )
 		);
 		$this->assertConditionsMet();
 	}
 
 	public function test_is_user_permissible_passes_correctly() {
-		\WP_Mock::userFunction( 'rest_authorization_required_code' )
+		WP_Mock::userFunction( 'rest_authorization_required_code' )
 			->andReturn( 403 );
 
-		\WP_Mock::userFunction( 'current_user_can' )
+		WP_Mock::userFunction( 'current_user_can' )
 			->with( 'administrator' )
 			->andReturn( true );
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_header' )
 			->with( 'X-WP-Nonce' )
 			->andReturn( 'a8ceg59jeqwvk' );
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->with( 'a8ceg59jeqwvk', 'wp_rest' )
 			->andReturn( true );
 

--- a/tests/php/Abstracts/ServiceTest.php
+++ b/tests/php/Abstracts/ServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace SqlToCpt\Tests\Abstracts;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Abstracts\Service;
 
@@ -11,11 +11,11 @@ use SqlToCpt\Abstracts\Service;
  */
 class ServiceTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_instance_returns_same_instance() {

--- a/tests/php/Core/ContainerTest.php
+++ b/tests/php/Core/ContainerTest.php
@@ -2,7 +2,7 @@
 
 namespace SqlToCpt\Tests\Core;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 
 use SqlToCpt\Core\Container;
@@ -28,11 +28,11 @@ class ContainerTest extends TestCase {
 	public Container $container;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_container_contains_required_services() {
@@ -47,7 +47,7 @@ class ContainerTest extends TestCase {
 	public function test_register() {
 		$container = new Container();
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'sql_to_cpt', [] )
 			->andReturn(
 				[
@@ -58,7 +58,7 @@ class ContainerTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_post_types',
 			[
 				'student',
@@ -76,7 +76,7 @@ class ContainerTest extends TestCase {
 			$service::get_instance();
 		}
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_menu',
 			[
 				Service::$services[ Admin::class ],
@@ -84,7 +84,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'init',
 			[
 				Service::$services[ Boot::class ],
@@ -92,7 +92,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectFilterAdded(
+		WP_Mock::expectFilterAdded(
 			'upload_mimes',
 			[
 				Service::$services[ Boot::class ],
@@ -100,7 +100,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_enqueue_scripts',
 			[
 				Service::$services[ Boot::class ],
@@ -108,7 +108,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'init',
 			[
 				Service::$services[ Post::class ],
@@ -116,7 +116,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'rest_api_init',
 			[
 				Service::$services[ Routes::class ],

--- a/tests/php/Core/ParserTest.php
+++ b/tests/php/Core/ParserTest.php
@@ -3,6 +3,8 @@
 namespace SqlToCpt\Tests\Core;
 
 use Mockery;
+use WP_Mock;
+use Exception;
 use WP_Mock\Tools\TestCase;
 
 use SqlToCpt\Core\Parser;
@@ -18,11 +20,11 @@ class ParserTest extends TestCase {
 	public Parser $parser;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_sql_string_throws_exception() {
@@ -31,11 +33,11 @@ class ParserTest extends TestCase {
 
 		$parser->sql = '/var/www/html/wp-content/uploads/import.sql';
 
-		\WP_Mock::userFunction( 'esc_url' )
+		WP_Mock::userFunction( 'esc_url' )
 			->with( '/var/www/html/wp-content/uploads/import.sql' )
 			->andReturn( '/var/www/html/wp-content/uploads/import.sql' );
 
-		$this->expectException( \Exception::class );
+		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Fatal Error: File does not exist: /var/www/html/wp-content/uploads/import.sql' );
 
 		$parser->get_sql_string();
@@ -65,7 +67,7 @@ class ParserTest extends TestCase {
 		$parser->shouldReceive( 'get_sql_string' )
 			->andReturn( 'INSERT INTO `student` (`id`, `name`, `age`, `sex`, `email_address`, `date_created`) VALUES' );
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_table_name', 'student' );
+		WP_Mock::expectFilter( 'sqlt_cpt_table_name', 'student' );
 
 		$this->assertSame( $parser->get_sql_table_name(), 'student' );
 		$this->assertConditionsMet();
@@ -78,7 +80,7 @@ class ParserTest extends TestCase {
 		$parser->shouldReceive( 'get_sql_string' )
 			->andReturn( '' );
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_table_name', '' );
+		WP_Mock::expectFilter( 'sqlt_cpt_table_name', '' );
 
 		$this->assertSame( $parser->get_sql_table_name(), '' );
 		$this->assertConditionsMet();
@@ -91,7 +93,7 @@ class ParserTest extends TestCase {
 		$parser->shouldReceive( 'get_sql_string' )
 			->andReturn( 'Invalid SQL string, no table name presented here.' );
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_table_name', '' );
+		WP_Mock::expectFilter( 'sqlt_cpt_table_name', '' );
 
 		$this->assertSame( $parser->get_sql_table_name(), '' );
 		$this->assertConditionsMet();
@@ -104,7 +106,7 @@ class ParserTest extends TestCase {
 		$parser->shouldReceive( 'get_sql_string' )
 			->andReturn( 'INSERT INTO `student` (`id`, `name`, `age`, `sex`, `email_address`, `date_created`) VALUES' );
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_table_columns',
 			[
 				'id',
@@ -168,14 +170,14 @@ class ParserTest extends TestCase {
 (1, 'Alice Smith', '20', 'Female', 'alice.smith@example.com', '2024-07-03 21:45:23');"
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_table_rows',
 			[
 				[
@@ -239,9 +241,9 @@ class ParserTest extends TestCase {
 
 		$sql_file = $this->create_sql_file( __DIR__ . '/import.sql' );
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_table_name', 'student' );
+		WP_Mock::expectFilter( 'sqlt_cpt_table_name', 'student' );
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_table_columns',
 			[
 				'id',
@@ -253,7 +255,7 @@ class ParserTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_table_rows',
 			[
 				[
@@ -283,7 +285,7 @@ class ParserTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;

--- a/tests/php/Core/PostTest.php
+++ b/tests/php/Core/PostTest.php
@@ -2,7 +2,7 @@
 
 namespace SqlToCpt\Tests\Core;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 
 use SqlToCpt\Core\Post;
@@ -24,13 +24,13 @@ class PostTest extends TestCase {
 	public Post $post;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->post = new Post( 'student' );
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_name() {
@@ -58,7 +58,7 @@ class PostTest extends TestCase {
 	}
 
 	public function test_get_options() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'__',
 			[
 				'return' => function ( $label, $text_domain = 'sql-to-cpt' ) {
@@ -67,7 +67,7 @@ class PostTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'sanitize_title',
 			[
 				'return' => function ( $text ) {
@@ -100,9 +100,9 @@ class PostTest extends TestCase {
 			],
 		];
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_post_labels', $student_post_labels );
+		WP_Mock::expectFilter( 'sqlt_cpt_post_labels', $student_post_labels );
 
-		\WP_Mock::onFilter( 'sqlt_cpt_post_options' )
+		WP_Mock::onFilter( 'sqlt_cpt_post_options' )
 			->with( $student_post_options )
 			->reply(
 				array_merge(
@@ -133,7 +133,7 @@ class PostTest extends TestCase {
 	}
 
 	public function test_get_labels() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'__',
 			[
 				'return' => function ( $label, $text_domain = 'sql-to-cpt' ) {
@@ -154,7 +154,7 @@ class PostTest extends TestCase {
 			'menu_name'     => 'Students',
 		];
 
-		\WP_Mock::onFilter( 'sqlt_cpt_post_labels' )
+		WP_Mock::onFilter( 'sqlt_cpt_post_labels' )
 			->with( $student_post_labels )
 			->reply(
 				array_merge(
@@ -186,7 +186,7 @@ class PostTest extends TestCase {
 	}
 
 	public function test_register_post_type() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'post_type_exists',
 			[
 				'return' => function ( $post_type ) {
@@ -197,7 +197,7 @@ class PostTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'__',
 			[
 				'return' => function ( $label, $text_domain = 'sql-to-cpt' ) {
@@ -206,7 +206,7 @@ class PostTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'sanitize_title',
 			[
 				'return' => function ( $text ) {
@@ -239,10 +239,10 @@ class PostTest extends TestCase {
 			],
 		];
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_post_labels', $student_post_labels );
-		\WP_Mock::expectFilter( 'sqlt_cpt_post_options', $student_post_options );
+		WP_Mock::expectFilter( 'sqlt_cpt_post_labels', $student_post_labels );
+		WP_Mock::expectFilter( 'sqlt_cpt_post_options', $student_post_options );
 
-		\WP_Mock::userFunction( 'register_post_type' )
+		WP_Mock::userFunction( 'register_post_type' )
 			->with( 'student', $student_post_options );
 
 		$this->post->register_post_type();

--- a/tests/php/Interfaces/KernelTest.php
+++ b/tests/php/Interfaces/KernelTest.php
@@ -2,7 +2,7 @@
 
 namespace SqlToCpt\Tests\Interfaces;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Interfaces\Kernel;
 
@@ -13,13 +13,13 @@ class KernelTest extends TestCase {
 	public Kernel $kernel;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->kernel = $this->getMockForAbstractClass( Kernel::class );
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {

--- a/tests/php/Interfaces/RouterTest.php
+++ b/tests/php/Interfaces/RouterTest.php
@@ -3,6 +3,8 @@
 namespace SqlToCpt\Tests\Interfaces;
 
 use Mockery;
+use WP_Mock;
+use WP_REST_Request;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Interfaces\Router;
 
@@ -15,13 +17,13 @@ class RouterTest extends TestCase {
 	public Router $router;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->router = $this->getMockForAbstractClass( Router::class );
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_response() {
@@ -37,7 +39,7 @@ class RouterTest extends TestCase {
 		$this->router->expects( $this->once() )
 			->method( 'request' );
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 
 		$this->router->request( $request );
 
@@ -48,7 +50,7 @@ class RouterTest extends TestCase {
 		$this->router->expects( $this->once() )
 			->method( 'is_user_permissible' );
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 
 		$this->router->is_user_permissible( $request );
 

--- a/tests/php/PluginTest.php
+++ b/tests/php/PluginTest.php
@@ -2,21 +2,20 @@
 
 namespace SqlToCpt\Tests;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Plugin;
-use SqlToCpt\Abstracts\Kernel;
 
 /**
  * @covers \SqlToCpt\Plugin::get_instance
  */
 class PluginTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_plugin_returns_same_instance() {

--- a/tests/php/Routes/ImportTest.php
+++ b/tests/php/Routes/ImportTest.php
@@ -3,9 +3,12 @@
 namespace SqlToCpt\Tests\Routes;
 
 use Mockery;
+use WP_Mock;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Routes\Import;
-use SqlToCpt\Abstracts\Service;
 
 /**
  * @covers \SqlToCpt\Routes\Import::response
@@ -17,13 +20,13 @@ class ImportTest extends TestCase {
 	public Import $import;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->import = new Import();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_route_initial_values() {
@@ -35,7 +38,7 @@ class ImportTest extends TestCase {
 		$import = Mockery::mock( Import::class )->makePartial();
 		$import->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -51,7 +54,7 @@ class ImportTest extends TestCase {
 
 		$response = $import->response();
 
-		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertConditionsMet();
 	}
 
@@ -59,7 +62,7 @@ class ImportTest extends TestCase {
 		$import = Mockery::mock( Import::class )->makePartial();
 		$import->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -71,7 +74,7 @@ class ImportTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_json_encode',
 			[
 				'times'  => 1,
@@ -85,7 +88,7 @@ class ImportTest extends TestCase {
 
 		$response = $import->response();
 
-		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertConditionsMet();
 	}
 
@@ -93,7 +96,7 @@ class ImportTest extends TestCase {
 		$import = Mockery::mock( Import::class )->makePartial();
 		$import->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -105,7 +108,7 @@ class ImportTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_json_encode',
 			[
 				'times'  => 1,
@@ -119,7 +122,7 @@ class ImportTest extends TestCase {
 
 		$response = $import->response();
 
-		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertConditionsMet();
 	}
 
@@ -127,10 +130,10 @@ class ImportTest extends TestCase {
 		$import = Mockery::mock( Import::class )->makePartial();
 		$import->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
-		$rest_response = Mockery::mock( \WP_REST_Response::class )->makePartial();
+		$rest_response = Mockery::mock( WP_REST_Response::class )->makePartial();
 		$rest_response->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -172,14 +175,14 @@ class ImportTest extends TestCase {
 				)
 			);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->times( 1 )
 			->with( 'https://example.com/wp-admin/edit.php?post_type=post' )
 			->andReturn( $rest_response );
 
 		$response = $import->response();
 
-		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertConditionsMet();
 	}
 
@@ -187,10 +190,10 @@ class ImportTest extends TestCase {
 		$import = Mockery::mock( Import::class )->makePartial();
 		$import->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
-		$rest_response = Mockery::mock( \WP_REST_Response::class )->makePartial();
+		$rest_response = Mockery::mock( WP_REST_Response::class )->makePartial();
 		$rest_response->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -223,7 +226,7 @@ class ImportTest extends TestCase {
 		$import->shouldReceive( 'get_response' )
 			->andReturn( null );
 
-		\WP_Mock::userFunction( '__' )
+		WP_Mock::userFunction( '__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -232,7 +235,7 @@ class ImportTest extends TestCase {
 
 		$response = $import->response();
 
-		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertConditionsMet();
 	}
 
@@ -273,7 +276,7 @@ class ImportTest extends TestCase {
 			],
 		];
 
-		\WP_Mock::userFunction( 'wp_json_encode' )
+		WP_Mock::userFunction( 'wp_json_encode' )
 			->twice()
 			->andReturnUsing(
 				function ( $arg ) {
@@ -313,7 +316,7 @@ class ImportTest extends TestCase {
 			],
 		];
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_post_values',
 			[
 				'post_type'   => 'student',
@@ -338,19 +341,19 @@ class ImportTest extends TestCase {
 			],
 		);
 
-		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error = Mockery::mock( WP_Error::class )->makePartial();
 		$wp_error->shouldAllowMockingProtectedMethods();
 
 		$wp_error->shouldReceive( 'get_error_message' )
 			->andReturn( 'Post ID: null' );
 
-		\WP_Mock::userFunction( 'wp_insert_post' )
+		WP_Mock::userFunction( 'wp_insert_post' )
 			->andReturn( $wp_error );
 
-		\WP_Mock::userFunction( 'is_wp_error' )
+		WP_Mock::userFunction( 'is_wp_error' )
 			->andReturnUsing(
 				function ( $arg ) {
-					return $arg instanceof \WP_Error;
+					return $arg instanceof WP_Error;
 				}
 			);
 
@@ -386,7 +389,7 @@ class ImportTest extends TestCase {
 			],
 		];
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_post_values',
 			[
 				'post_type'   => 'student',
@@ -411,31 +414,31 @@ class ImportTest extends TestCase {
 			],
 		);
 
-		\WP_Mock::userFunction( 'wp_insert_post' )
+		WP_Mock::userFunction( 'wp_insert_post' )
 			->andReturn( 1 );
 
-		\WP_Mock::userFunction( 'is_wp_error' )
+		WP_Mock::userFunction( 'is_wp_error' )
 			->andReturnUsing(
 				function ( $arg ) {
-					return $arg instanceof \WP_Error;
+					return $arg instanceof WP_Error;
 				}
 			);
 
-		\WP_Mock::userFunction( 'add_query_arg' )
+		WP_Mock::userFunction( 'add_query_arg' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {
 					return sprintf( '%s?%s', $arg2, http_build_query( $arg1 ) );
 				}
 			);
 
-		\WP_Mock::userFunction( 'untrailingslashit' )
+		WP_Mock::userFunction( 'untrailingslashit' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return mb_strrchr( $arg, '/', true );
 				}
 			);
 
-		\WP_Mock::userFunction( 'get_admin_url' )
+		WP_Mock::userFunction( 'get_admin_url' )
 			->andReturn( 'https://example.com/wp-admin/' );
 
 		$import->shouldReceive( 'get_post_type' )
@@ -456,7 +459,7 @@ class ImportTest extends TestCase {
 
 		$import->args['tableName'] = 'student';
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'sql_to_cpt', [] )
 			->andReturn(
 				[
@@ -480,7 +483,7 @@ class ImportTest extends TestCase {
 
 		$import->args['tableName'] = 'student';
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'sql_to_cpt', [] )
 			->andReturn(
 				[
@@ -491,7 +494,7 @@ class ImportTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'update_option' )
+		WP_Mock::userFunction( 'update_option' )
 			->andReturn(
 				[
 					'cpts' => [

--- a/tests/php/Routes/ParseTest.php
+++ b/tests/php/Routes/ParseTest.php
@@ -3,11 +3,14 @@
 namespace SqlToCpt\Tests\Routes;
 
 use Mockery;
+use WP_Mock;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_Mock\Tools\TestCase;
 
 use SqlToCpt\Core\Parser;
 use SqlToCpt\Routes\Parse;
-use SqlToCpt\Abstracts\Service;
 
 /**
  * @covers \SqlToCpt\Routes\Parse::is_sql
@@ -24,13 +27,13 @@ class ParseTest extends TestCase {
 	public Parse $parse;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->parse = new Parse();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_route_initial_values() {
@@ -42,7 +45,7 @@ class ParseTest extends TestCase {
 		$parse = Mockery::mock( Parse::class )->makePartial();
 		$parse->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -52,13 +55,13 @@ class ParseTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'get_attached_file' )
+		WP_Mock::userFunction( 'get_attached_file' )
 			->with( '' )
 			->andReturn( false );
 
 		$parse->request = $request;
 
-		$this->assertInstanceOf( \WP_Error::class, $parse->response() );
+		$this->assertInstanceOf( WP_Error::class, $parse->response() );
 		$this->assertConditionsMet();
 	}
 
@@ -69,7 +72,7 @@ class ParseTest extends TestCase {
 		$parse = Mockery::mock( Parse::class )->makePartial();
 		$parse->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -81,7 +84,7 @@ class ParseTest extends TestCase {
 
 		$parse->request = $request;
 
-		\WP_Mock::userFunction( 'get_attached_file' )
+		WP_Mock::userFunction( 'get_attached_file' )
 			->with( 1 )
 			->andReturn( $txt_file );
 
@@ -93,7 +96,7 @@ class ParseTest extends TestCase {
 				}
 			);
 
-		$this->assertInstanceOf( \WP_Error::class, $parse->response() );
+		$this->assertInstanceOf( WP_Error::class, $parse->response() );
 		$this->assertConditionsMet();
 
 		$this->destroy_mock_file( $txt_file );
@@ -106,10 +109,10 @@ class ParseTest extends TestCase {
 		$parse = Mockery::mock( Parse::class )->makePartial();
 		$parse->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
-		$rest_response = Mockery::mock( \WP_REST_Response::class )->makePartial();
+		$rest_response = Mockery::mock( WP_REST_Response::class )->makePartial();
 		$rest_response->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -121,7 +124,7 @@ class ParseTest extends TestCase {
 
 		$parse->request = $request;
 
-		\WP_Mock::userFunction( 'get_attached_file' )
+		WP_Mock::userFunction( 'get_attached_file' )
 			->with( 1 )
 			->andReturn( $sql_file );
 
@@ -144,7 +147,7 @@ class ParseTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->once()
 			->with(
 				[
@@ -157,7 +160,7 @@ class ParseTest extends TestCase {
 			)
 			->andReturn( $rest_response );
 
-		$this->assertInstanceOf( \WP_REST_Response::class, $parse->response() );
+		$this->assertInstanceOf( WP_REST_Response::class, $parse->response() );
 		$this->assertConditionsMet();
 
 		$this->destroy_mock_file( $sql_file );
@@ -170,7 +173,7 @@ class ParseTest extends TestCase {
 		$parser = Mockery::mock( Parser::class )->makePartial();
 		$parser->shouldAllowMockingProtectedMethods();
 
-		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error = Mockery::mock( WP_Error::class )->makePartial();
 		$wp_error->shouldAllowMockingProtectedMethods();
 
 		$parse->file = '';
@@ -180,7 +183,7 @@ class ParseTest extends TestCase {
 
 		$response = $parse->get_response( $parser );
 
-		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertConditionsMet();
 	}
 
@@ -195,9 +198,9 @@ class ParseTest extends TestCase {
 
 		$parse->file = $sql_file;
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_table_name', 'student' );
+		WP_Mock::expectFilter( 'sqlt_cpt_table_name', 'student' );
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_table_columns',
 			[
 				'id',
@@ -209,7 +212,7 @@ class ParseTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_table_rows',
 			[
 				[
@@ -239,7 +242,7 @@ class ParseTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -292,7 +295,7 @@ class ParseTest extends TestCase {
 		$parse = Mockery::mock( Parse::class )->makePartial();
 		$parse->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'wp_check_filetype' )
+		WP_Mock::userFunction( 'wp_check_filetype' )
 			->with( $file_path )
 			->andReturnUsing(
 				function ( $path ) {
@@ -312,7 +315,7 @@ class ParseTest extends TestCase {
 		$parse = Mockery::mock( Parse::class )->makePartial();
 		$parse->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'wp_check_filetype' )
+		WP_Mock::userFunction( 'wp_check_filetype' )
 			->with( $file_path )
 			->andReturnUsing(
 				function ( $path ) {

--- a/tests/php/Routes/PurgeTest.php
+++ b/tests/php/Routes/PurgeTest.php
@@ -3,10 +3,14 @@
 namespace SqlToCpt\Tests\Routes;
 
 use Mockery;
+use WP_Mock;
+use WP_Post;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_Mock\Tools\TestCase;
 
 use SqlToCpt\Routes\Purge;
-use SqlToCpt\Abstracts\Service;
 
 /**
  * @covers \SqlToCpt\Routes\Purge::response
@@ -19,13 +23,13 @@ class PurgeTest extends TestCase {
 	public Purge $purge;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->purge = new Purge();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_route_initial_values() {
@@ -37,10 +41,10 @@ class PurgeTest extends TestCase {
 		$purge = Mockery::mock( Purge::class )->makePartial();
 		$purge->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( '__' )
+		WP_Mock::userFunction( '__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -56,7 +60,7 @@ class PurgeTest extends TestCase {
 
 		$purge->request = $request;
 
-		$this->assertInstanceOf( \WP_Error::class, $purge->response() );
+		$this->assertInstanceOf( WP_Error::class, $purge->response() );
 		$this->assertConditionsMet();
 	}
 
@@ -64,7 +68,7 @@ class PurgeTest extends TestCase {
 		$purge = Mockery::mock( Purge::class )->makePartial();
 		$purge->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -79,7 +83,7 @@ class PurgeTest extends TestCase {
 
 		$purge->request = $request;
 
-		$this->assertInstanceOf( \WP_Error::class, $purge->response() );
+		$this->assertInstanceOf( WP_Error::class, $purge->response() );
 		$this->assertConditionsMet();
 	}
 
@@ -87,10 +91,10 @@ class PurgeTest extends TestCase {
 		$purge = Mockery::mock( Purge::class )->makePartial();
 		$purge->shouldAllowMockingProtectedMethods();
 
-		$request = Mockery::mock( \WP_REST_Request::class )->makePartial();
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
-		$rest_response = Mockery::mock( \WP_REST_Response::class )->makePartial();
+		$rest_response = Mockery::mock( WP_REST_Response::class )->makePartial();
 		$rest_response->shouldAllowMockingProtectedMethods();
 
 		$request->shouldReceive( 'get_json_params' )
@@ -106,7 +110,7 @@ class PurgeTest extends TestCase {
 		$purge->shouldReceive( 'get_updated_cpts' )
 			->andReturn( [ 'lecturer', 'department' ] );
 
-		\WP_Mock::userFunction( 'rest_ensure_response' )
+		WP_Mock::userFunction( 'rest_ensure_response' )
 			->with(
 				[
 					'message'  => 'Posts deleted succesfully for custom Post Type: student',
@@ -117,7 +121,7 @@ class PurgeTest extends TestCase {
 
 		$purge->request = $request;
 
-		$this->assertInstanceOf( \WP_REST_Response::class, $purge->response() );
+		$this->assertInstanceOf( WP_REST_Response::class, $purge->response() );
 		$this->assertConditionsMet();
 	}
 
@@ -128,7 +132,7 @@ class PurgeTest extends TestCase {
 		$purge->shouldReceive( 'get_post_ids' )
 			->andReturn( [ 1, 2, 3 ] );
 
-		\WP_Mock::userFunction( 'wp_delete_post' )
+		WP_Mock::userFunction( 'wp_delete_post' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg % 2;
@@ -148,7 +152,7 @@ class PurgeTest extends TestCase {
 		$purge->shouldReceive( 'get_post_ids' )
 			->andReturn( [ 1, 2, 3 ] );
 
-		\WP_Mock::userFunction( 'wp_delete_post' )
+		WP_Mock::userFunction( 'wp_delete_post' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return null;
@@ -168,7 +172,7 @@ class PurgeTest extends TestCase {
 		$purge->shouldReceive( 'get_post_ids' )
 			->andReturn( [ 1, 2, 3 ] );
 
-		\WP_Mock::userFunction( 'wp_delete_post' )
+		WP_Mock::userFunction( 'wp_delete_post' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -185,16 +189,16 @@ class PurgeTest extends TestCase {
 		$purge = Mockery::mock( Purge::class )->makePartial();
 		$purge->shouldAllowMockingProtectedMethods();
 
-		$post1     = Mockery::mock( \WP_Post::class )->makePartial();
+		$post1     = Mockery::mock( WP_Post::class )->makePartial();
 		$post1->ID = 1;
 
-		$post2     = Mockery::mock( \WP_Post::class )->makePartial();
+		$post2     = Mockery::mock( WP_Post::class )->makePartial();
 		$post2->ID = 2;
 
-		$post3     = Mockery::mock( \WP_Post::class )->makePartial();
+		$post3     = Mockery::mock( WP_Post::class )->makePartial();
 		$post3->ID = 3;
 
-		\WP_Mock::userFunction( 'get_posts' )
+		WP_Mock::userFunction( 'get_posts' )
 			->once()
 			->with(
 				[
@@ -210,7 +214,7 @@ class PurgeTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'wp_list_pluck' )
+		WP_Mock::userFunction( 'wp_list_pluck' )
 			->with(
 				[
 					$post1,
@@ -242,7 +246,7 @@ class PurgeTest extends TestCase {
 		$purge = Mockery::mock( Purge::class )->makePartial();
 		$purge->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'sql_to_cpt', [] )
 			->andReturn(
@@ -251,7 +255,7 @@ class PurgeTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'update_option' )
+		WP_Mock::userFunction( 'update_option' )
 			->once()
 			->with(
 				'sql_to_cpt',

--- a/tests/php/Services/AdminTest.php
+++ b/tests/php/Services/AdminTest.php
@@ -2,10 +2,9 @@
 
 namespace SqlToCpt\Tests\Services;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Services\Admin;
-use SqlToCpt\Abstracts\Service;
 
 /**
  * @covers \SqlToCpt\Services\Admin::register
@@ -16,17 +15,17 @@ class AdminTest extends TestCase {
 	public Admin $admin;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->admin = new Admin();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_admin_menu' ] );
+		WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_admin_menu' ] );
 
 		$this->admin->register();
 
@@ -34,14 +33,14 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_admin_menu() {
-		\WP_Mock::userFunction( '__' )
+		WP_Mock::userFunction( '__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'add_menu_page' )
+		WP_Mock::userFunction( 'add_menu_page' )
 			->with(
 				'SQL to CPT',
 				'SQL to CPT',
@@ -59,7 +58,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_admin_page() {
-		\WP_Mock::userFunction( 'esc_html__' )
+		WP_Mock::userFunction( 'esc_html__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -86,7 +86,6 @@ class BootTest extends TestCase {
 
 		$boot = new ReflectionClass( Boot::class );
 
-		WP_Mock::userFunction( 'plugin_dir_url' )
 		$mock_boot = Mockery::mock( Boot::class )->makePartial();
 		$mock_boot->shouldAllowMockingProtectedMethods();
 
@@ -105,7 +104,7 @@ class BootTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'plugin_dir_url' )
+		WP_Mock::userFunction( 'plugin_dir_url' )
 			->with( $boot->getFileName() )
 			->andReturn( 'https://example.com/wp-content/plugins/sql-to-cpt/inc/Services/Boot.php' );
 

--- a/tests/php/Services/BootTest.php
+++ b/tests/php/Services/BootTest.php
@@ -3,9 +3,11 @@
 namespace SqlToCpt\Tests\Services;
 
 use Mockery;
+use WP_Mock;
+use WP_Screen;
+use ReflectionClass;
 use WP_Mock\Tools\TestCase;
 use SqlToCpt\Services\Boot;
-use SqlToCpt\Abstracts\Service;
 
 /**
  * @covers \SqlToCpt\Services\Boot::register
@@ -17,19 +19,19 @@ class BootTest extends TestCase {
 	public Boot $boot;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->boot = new Boot();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'init', [ $this->boot, 'register_translation' ] );
-		\WP_Mock::expectFilterAdded( 'upload_mimes', [ $this->boot, 'register_mimes' ] );
-		\WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->boot, 'register_scripts' ] );
+		WP_Mock::expectActionAdded( 'init', [ $this->boot, 'register_translation' ] );
+		WP_Mock::expectFilterAdded( 'upload_mimes', [ $this->boot, 'register_mimes' ] );
+		WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->boot, 'register_scripts' ] );
 
 		$this->boot->register();
 
@@ -39,7 +41,7 @@ class BootTest extends TestCase {
 	public function test_register_scripts_bails_out_if_screen_is_null() {
 		$screen = null;
 
-		\WP_Mock::userFunction( 'get_current_screen' )
+		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( $screen );
 
 		$this->boot->register_scripts();
@@ -50,7 +52,7 @@ class BootTest extends TestCase {
 	public function test_register_scripts_bails_out_if_it_is_not_an_object() {
 		$screen = 1;
 
-		\WP_Mock::userFunction( 'get_current_screen' )
+		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( $screen );
 
 		$this->boot->register_scripts();
@@ -59,12 +61,12 @@ class BootTest extends TestCase {
 	}
 
 	public function test_register_scripts_bails_out_if_it_is_not_plugin_page() {
-		$screen = Mockery::mock( \WP_Screen::class )->makePartial();
+		$screen = Mockery::mock( WP_Screen::class )->makePartial();
 		$screen->shouldAllowMockingProtectedMethods();
 
 		$screen->id = 'toplevel_page_hello-world';
 
-		\WP_Mock::userFunction( 'get_current_screen' )
+		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( $screen );
 
 		$this->boot->register_scripts();
@@ -73,25 +75,25 @@ class BootTest extends TestCase {
 	}
 
 	public function test_register_scripts() {
-		$screen = Mockery::mock( \WP_Screen::class )->makePartial();
+		$screen = Mockery::mock( WP_Screen::class )->makePartial();
 		$screen->shouldAllowMockingProtectedMethods();
 
 		$screen->id = 'toplevel_page_sql-to-cpt';
 
-		\WP_Mock::userFunction( 'get_current_screen' )
+		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( $screen );
 
-		$boot = new \ReflectionClass( Boot::class );
+		$boot = new ReflectionClass( Boot::class );
 
-		\WP_Mock::userFunction( 'plugin_dir_url' )
+		WP_Mock::userFunction( 'plugin_dir_url' )
 			->with( $boot->getFileName() )
 			->andReturn( 'https://example.com/wp-content/plugins/sql-to-cpt/inc/Services/Boot.php' );
 
-		\WP_Mock::userFunction( 'plugin_dir_path' )
+		WP_Mock::userFunction( 'plugin_dir_path' )
 			->with( $boot->getFileName() )
 			->andReturn( '/var/www/html/wp-content/plugins/sql-to-cpt/inc/Services/Boot.php/' );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'trailingslashit',
 			[
 				'return' => function ( $text ) {
@@ -100,7 +102,7 @@ class BootTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'wp_enqueue_script' )
+		WP_Mock::userFunction( 'wp_enqueue_script' )
 			->with(
 				'sql-to-cpt',
 				'https://example.com/wp-content/plugins/sql-to-cpt/inc/Services/Boot.php/../../dist/app.js',
@@ -119,11 +121,11 @@ class BootTest extends TestCase {
 				false,
 			);
 
-		\WP_Mock::userFunction( 'wp_enqueue_media' )
+		WP_Mock::userFunction( 'wp_enqueue_media' )
 			->with()
 			->andReturn( null );
 
-		\WP_Mock::userFunction( 'wp_set_script_translations' )
+		WP_Mock::userFunction( 'wp_set_script_translations' )
 			->with(
 				'sql-to-cpt',
 				'sql-to-cpt',
@@ -131,7 +133,7 @@ class BootTest extends TestCase {
 			)
 			->andReturn( null );
 
-			\WP_Mock::userFunction( 'get_option' )
+			WP_Mock::userFunction( 'get_option' )
 				->once()
 				->with( 'sql_to_cpt', [] )
 				->andReturn(
@@ -140,7 +142,7 @@ class BootTest extends TestCase {
 					]
 				);
 
-		\WP_Mock::userFunction( 'wp_localize_script' )
+		WP_Mock::userFunction( 'wp_localize_script' )
 			->once()
 			->with(
 				'sql-to-cpt',
@@ -157,14 +159,14 @@ class BootTest extends TestCase {
 	}
 
 	public function test_register_translation() {
-		$boot = new \ReflectionClass( Boot::class );
+		$boot = new ReflectionClass( Boot::class );
 
-		\WP_Mock::userFunction( 'plugin_basename' )
+		WP_Mock::userFunction( 'plugin_basename' )
 			->once()
 			->with( $boot->getFileName() )
 			->andReturn( '/inc/Services/Boot.php' );
 
-		\WP_Mock::userFunction( 'load_plugin_textdomain' )
+		WP_Mock::userFunction( 'load_plugin_textdomain' )
 			->once()
 			->with(
 				'sql-to-cpt',
@@ -178,7 +180,7 @@ class BootTest extends TestCase {
 	}
 
 	public function test_register_mimes() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_parse_args',
 			[
 				'times'  => 1,

--- a/tests/php/Services/PostTest.php
+++ b/tests/php/Services/PostTest.php
@@ -2,11 +2,10 @@
 
 namespace SqlToCpt\Tests\Services;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 
 use SqlToCpt\Services\Post;
-use SqlToCpt\Abstracts\Service;
 use SqlToCpt\Core\Post as CPT;
 
 /**
@@ -29,9 +28,9 @@ class PostTest extends TestCase {
 	public Post $post;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'sql_to_cpt', [] )
 			->andReturn(
 				[
@@ -42,7 +41,7 @@ class PostTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'sqlt_cpt_post_types',
 			[
 				'student',
@@ -54,7 +53,7 @@ class PostTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_post_objects_contains_instances_of_CPTs() {
@@ -64,7 +63,7 @@ class PostTest extends TestCase {
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'init', [ $this->post, 'register_post_types' ] );
+		WP_Mock::expectActionAdded( 'init', [ $this->post, 'register_post_types' ] );
 
 		$this->post->register();
 
@@ -72,7 +71,7 @@ class PostTest extends TestCase {
 	}
 
 	public function test_register_post_types_does_nothing_if_post_types_are_already_registered() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'post_type_exists',
 			[
 				'return' => function ( $post_type ) {
@@ -89,7 +88,7 @@ class PostTest extends TestCase {
 	}
 
 	public function test_registers_post_types() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'post_type_exists',
 			[
 				'return' => function ( $post_type ) {
@@ -100,7 +99,7 @@ class PostTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'__',
 			[
 				'return' => function ( $label, $text_domain = 'sql-to-cpt' ) {
@@ -109,7 +108,7 @@ class PostTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'sanitize_title',
 			[
 				'return' => function ( $text ) {
@@ -166,16 +165,16 @@ class PostTest extends TestCase {
 			],
 		];
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_post_labels', $student_post_labels );
-		\WP_Mock::expectFilter( 'sqlt_cpt_post_labels', $department_post_labels );
+		WP_Mock::expectFilter( 'sqlt_cpt_post_labels', $student_post_labels );
+		WP_Mock::expectFilter( 'sqlt_cpt_post_labels', $department_post_labels );
 
-		\WP_Mock::expectFilter( 'sqlt_cpt_post_options', $student_post_options );
-		\WP_Mock::expectFilter( 'sqlt_cpt_post_options', $department_post_options );
+		WP_Mock::expectFilter( 'sqlt_cpt_post_options', $student_post_options );
+		WP_Mock::expectFilter( 'sqlt_cpt_post_options', $department_post_options );
 
-		\WP_Mock::userFunction( 'register_post_type' )
+		WP_Mock::userFunction( 'register_post_type' )
 			->with( 'student', $student_post_options );
 
-		\WP_Mock::userFunction( 'register_post_type' )
+		WP_Mock::userFunction( 'register_post_type' )
 			->with( 'department', $department_post_options );
 
 		$this->post->register_post_types();

--- a/tests/php/Services/RoutesTest.php
+++ b/tests/php/Services/RoutesTest.php
@@ -2,15 +2,13 @@
 
 namespace SqlToCpt\Tests\Services;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 
 use SqlToCpt\Routes\Parse;
 use SqlToCpt\Routes\Purge;
 use SqlToCpt\Routes\Import;
 use SqlToCpt\Services\Routes;
-use SqlToCpt\Abstracts\Route;
-use SqlToCpt\Abstracts\Service;
 
 /**
  * @covers \SqlToCpt\Services\Routes::register
@@ -22,17 +20,17 @@ class RoutesTest extends TestCase {
 	public Routes $routes;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->routes = new Routes();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'rest_api_init', [ $this->routes, 'register_rest_routes' ] );
+		WP_Mock::expectActionAdded( 'rest_api_init', [ $this->routes, 'register_rest_routes' ] );
 
 		$this->routes->register();
 
@@ -53,7 +51,7 @@ class RoutesTest extends TestCase {
 	}
 
 	public function test_register_rest_routes() {
-		\WP_Mock::onFilter( 'sqlt_cpt_rest_routes' )
+		WP_Mock::onFilter( 'sqlt_cpt_rest_routes' )
 			->with(
 				[
 					Parse::class,
@@ -69,7 +67,7 @@ class RoutesTest extends TestCase {
 
 		$import = new Import();
 
-		\WP_Mock::userFunction( 'register_rest_route' )
+		WP_Mock::userFunction( 'register_rest_route' )
 			->with(
 				'sql-to-cpt/v1',
 				'/import',


### PR DESCRIPTION
This PR resolves [WP-46](https://appworld.atlassian.net/browse/WP-46)

## Description / Background Context

At the moment, the classes used are fully qualified path, we intend to use their `use` counter part

## Testing Instructions

- Pull PR to local.
- Then proceed to the plugin page.
- Upload a `.sql` file and convert to `cpt`.
- Observe that there was no error and the `cpt` was created successfully.





