### PR TITLE
Refactor: Replace hard coded http verb with WP_REST_Server constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+* Refactor: Replaced hard coded HTTP verbs with `WP_REST_Server` constant.
+
 ## 1.3.4
 * Specify `wordpress-plugin` as Composer package type.
 * Tested up to WP 6.9.

--- a/inc/Routes/Import.php
+++ b/inc/Routes/Import.php
@@ -10,6 +10,7 @@
 
 namespace SqlToCpt\Routes;
 
+use WP_REST_Server;
 use SqlToCpt\Abstracts\Route;
 use SqlToCpt\Interfaces\Router;
 
@@ -24,7 +25,7 @@ class Import extends Route implements Router {
 	 *
 	 * @var string
 	 */
-	public string $method = 'POST';
+	public string $method = WP_REST_Server::CREATABLE;
 
 	/**
 	 * WP REST Endpoint e.g. /wp-json/sql-to-cpt/v1/import.

--- a/inc/Routes/Parse.php
+++ b/inc/Routes/Parse.php
@@ -10,6 +10,7 @@
 
 namespace SqlToCpt\Routes;
 
+use WP_REST_Server;
 use SqlToCpt\Core\Parser;
 use SqlToCpt\Abstracts\Route;
 use SqlToCpt\Interfaces\Router;
@@ -25,7 +26,7 @@ class Parse extends Route implements Router {
 	 *
 	 * @var string
 	 */
-	public string $method = 'POST';
+	public string $method = WP_REST_Server::CREATABLE;
 
 	/**
 	 * WP REST Endpoint e.g. /wp-json/sql-to-cpt/v1/parse.

--- a/inc/Routes/Purge.php
+++ b/inc/Routes/Purge.php
@@ -10,6 +10,7 @@
 
 namespace SqlToCpt\Routes;
 
+use WP_REST_Server;
 use SqlToCpt\Abstracts\Route;
 use SqlToCpt\Interfaces\Router;
 
@@ -24,7 +25,7 @@ class Purge extends Route implements Router {
 	 *
 	 * @var string
 	 */
-	public string $method = 'POST';
+	public string $method = WP_REST_Server::CREATABLE;
 
 	/**
 	 * WP REST Endpoint e.g. /wp-json/sql-to-cpt/v1/purge.

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.4.0
+* Refactor: Replaced hard coded HTTP verbs with `WP_REST_Server` constant.
+
 = 1.3.4
 * Specify `wordpress-plugin` as Composer package type.
 * Tested up to WP 6.9.

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -15,7 +15,7 @@ require_once dirname( __DIR__ ) . '/../vendor/autoload.php';
 WP_Mock::activateStrictMode();
 WP_Mock::bootstrap();
 
-if( ! class_exists( 'WP_REST_Server') ){
+if ( ! class_exists( 'WP_REST_Server' ) ) {
 	class WP_REST_Server {
 		const READABLE   = 'GET';
 		const CREATABLE  = 'POST';

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -14,3 +14,13 @@ require_once dirname( __DIR__ ) . '/../vendor/autoload.php';
 // Bootstrap WP_Mock.
 WP_Mock::activateStrictMode();
 WP_Mock::bootstrap();
+
+if( ! class_exists( 'WP_REST_Server') ){
+	class WP_REST_Server {
+		const READABLE   = 'GET';
+		const CREATABLE  = 'POST';
+		const EDITABLE   = 'PUT, PATCH';
+		const DELETABLE  = 'DELETE';
+		const ALLMETHODS = 'GET, POST, PUT, PATCH, DELETE';
+	}
+}


### PR DESCRIPTION
This PR resolves [WP-47](https://appworld.atlassian.net/browse/WP-47)

## Description / Background Context

At the moment, HTTP verbs are used for server action, we intend to change them to `WP_REST_Server` constant.
## Testing Instructions

- Pull PR to local.
## For QA 
- Then proceed to the plugin page.
- Upload a `.sql` file and convert to `cpt`.
- Observe that there was no error and the `cpt` was created successfully.
## For Engineers
- Proceed to the `Routes` folder inside of `inc` directory.
- Check every files inside that folder and observe that `POST` doesn't exist and has been replaced with `WP_REST_Server::CREATABLE`.





