### PR TITLE
Feat: Implement custom `sql-to-cpt` store to prevent props drilling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,17 @@
-const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
-
 module.exports = {
-	...baseConfig,
-	preset: 'ts-jest',
+	verbose: true,
+	preset: '@wordpress/jest-preset-default',
 	testEnvironment: 'jsdom',
 	setupFilesAfterEnv: [ './jest.setup.js' ],
+	globals: {
+		window: {},
+	},
 	transform: {
-		'^.+\\.jsx?$': 'babel-jest',
+		'^.+\\.[jt]sx?$': 'babel-jest',
 	},
 	moduleNameMapper: {
 		uuid: require.resolve( 'uuid' ),
+		'\\.(css|less|scss|sass)$': 'identity-obj-proxy',
 	},
+	modulePathIgnorePatterns: [ '/__snapshots__/' ],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,6 @@
+/* eslint-disable no-undef */
 import '@testing-library/jest-dom';
-import '@testing-library/jest-dom/extend-expect.js';
-import '@wordpress/jest-preset-default/scripts/setup-globals';
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( props ) => <button { ...props } />,
+} ) );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,16 @@ import {
 import '../store';
 import '../styles/app.scss';
 
+/**
+ * App Component.
+ *
+ * This function returns a JSX component that comprises
+ * the Import Button and Fields.
+ *
+ * @since 1.0.0
+ *
+ * @return {JSX.Element} The App component.
+ */
 const App = (): JSX.Element => {
 	return (
 		<main>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,57 +1,26 @@
-import { useState } from '@wordpress/element';
-
-import Purge from '../components/Purge';
-import Notice from '../components/Notice';
-import TableName from '../components/TableName';
-import ProgressBar from '../components/ProgressBar';
-import TableColumns from '../components/TableColumns';
-import ImportButton from '../components/ImportButton';
-
+import {
+	ImportButton,
+	Notice,
+	ProgressBar,
+	Purge,
+	TableName,
+	TableColumns,
+} from '../components/All';
+import '../store';
 import '../styles/app.scss';
 
-interface SQLProps {
-	tableName: string;
-	tableColumns: string[];
-	tableRows: any[];
-}
-
-/**
- * App Component.
- *
- * This function returns a JSX component that comprises
- * the Import Button and Fields.
- *
- * @since 1.0.0
- *
- * @return {JSX.Element} The App component.
- */
 const App = (): JSX.Element => {
-	const [ isLoading, setIsLoading ] = useState< boolean >( false );
-	const [ sqlNotice, setSqlNotice ] = useState< string >( '' );
-	const [ parsedSQL, setParsedSQL ] = useState< SQLProps >( {
-		tableName: '',
-		tableColumns: [],
-		tableRows: [],
-	} );
-
 	return (
 		<main>
 			<section>
-				<ImportButton
-					parsedSQL={ parsedSQL }
-					setIsLoading={ setIsLoading }
-					setSqlNotice={ setSqlNotice }
-					setParsedSQL={ setParsedSQL }
-				/>
-				<Purge
-					setIsLoading={ setIsLoading }
-					setSqlNotice={ setSqlNotice }
-				/>
+				<ImportButton />
+				<Purge />
 			</section>
-			<Notice message={ sqlNotice } />
-			<ProgressBar isLoading={ isLoading } />
-			<TableName parsedSQL={ parsedSQL } />
-			<TableColumns parsedSQL={ parsedSQL } />
+
+			<Notice />
+			<ProgressBar />
+			<TableName />
+			<TableColumns />
 		</main>
 	);
 };

--- a/src/components/All.tsx
+++ b/src/components/All.tsx
@@ -1,0 +1,8 @@
+import ImportButton from '../components/ImportButton';
+import Notice from '../components/Notice';
+import ProgressBar from '../components/ProgressBar';
+import Purge from '../components/Purge';
+import TableName from '../components/TableName';
+import TableColumns from '../components/TableColumns';
+
+export { ImportButton, Notice, ProgressBar, Purge, TableName, TableColumns };

--- a/src/components/ImportButton.tsx
+++ b/src/components/ImportButton.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import type { MediaFrame } from '@wordpress/media-utils';
+import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 import { getModalParams } from '../utils';
@@ -22,13 +23,20 @@ interface ImportButtonProps {
  * This function returns a JSX component that is
  * used to display the Import Button.
  *
- * @param  props
  * @since 1.2.0
  *
  * @return {JSX.Element} The Import Button component.
  */
-const ImportButton = ( props: ImportButtonProps ): JSX.Element => {
-	const { parsedSQL, setIsLoading, setSqlNotice, setParsedSQL } = props;
+const ImportButton = (): JSX.Element => {
+	const { setIsLoading, setSqlNotice, setParsedSQL } =
+		useDispatch( 'sql-to-cpt' );
+	const { parsedSQL } = useSelect( ( select ) => {
+		const store: any = select( 'sql-to-cpt' );
+
+		return {
+			parsedSQL: store.getParsedSQL(),
+		};
+	}, [] );
 
 	/**
 	 * Handle Upload.

--- a/src/components/ImportButton.tsx
+++ b/src/components/ImportButton.tsx
@@ -1,21 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import type { MediaFrame } from '@wordpress/media-utils';
-import { useSelect, useDispatch } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
 
-import { getModalParams } from '../utils';
-
-interface ImportButtonProps {
-	parsedSQL: {
-		tableName: string;
-		tableRows: any[];
-		tableColumns: string[];
-	};
-	setIsLoading: Function;
-	setSqlNotice: Function;
-	setParsedSQL: Function;
-}
+import { handleImport, handleUpload } from '../utils';
 
 /**
  * Import Button Component.
@@ -28,8 +15,6 @@ interface ImportButtonProps {
  * @return {JSX.Element} The Import Button component.
  */
 const ImportButton = (): JSX.Element => {
-	const { setIsLoading, setSqlNotice, setParsedSQL } =
-		useDispatch( 'sql-to-cpt' );
 	const { parsedSQL } = useSelect( ( select ) => {
 		const store: any = select( 'sql-to-cpt' );
 
@@ -38,104 +23,22 @@ const ImportButton = (): JSX.Element => {
 		};
 	}, [] );
 
-	/**
-	 * Handle Upload.
-	 *
-	 * This function is responsible for opening the
-	 * WP media modal to enable user select.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return {void}
-	 */
-	const handleUpload = (): void => {
-		const wpMediaModal = wp.media( getModalParams() );
-		wpMediaModal.on( 'select', () => handleSelect( wpMediaModal ) ).open();
-	};
-
-	/**
-	 * Handle Selection.
-	 *
-	 * This function is responsible for handling a
-	 * selection made by the user.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param {MediaFrame} wpMediaModal WP Media Modal.
-	 * @return Promise<void>
-	 */
-	const handleSelect = async (
-		wpMediaModal: MediaFrame
-	): Promise< void > => {
-		const args = wpMediaModal.state().get( 'selection' ).first().toJSON();
-
-		// Reset.
-		setSqlNotice( '' );
-		setParsedSQL( {
-			tableName: '',
-			tableColumns: [],
-			tableRows: [],
-		} );
-		setIsLoading( true );
-
-		// Parse SQL.
-		try {
-			setParsedSQL(
-				await apiFetch( {
-					path: '/sql-to-cpt/v1/parse',
-					method: 'POST',
-					data: {
-						...args,
-					},
-				} )
-			);
-			setIsLoading( false );
-		} catch ( { message } ) {
-			setIsLoading( false );
-			setSqlNotice( message );
-		}
-	};
-
-	/**
-	 * Handle Import.
-	 *
-	 * This function is responsible for handling the
-	 * import made by the user.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @return Promise<void>
-	 */
-	const handleImport = async (): Promise< void > => {
-		setIsLoading( true );
-
-		// Import SQL.
-		try {
-			const url = await apiFetch( {
-				path: '/sql-to-cpt/v1/import',
-				method: 'POST',
-				data: {
-					...parsedSQL,
-				},
-			} );
-			if ( url ) {
-				window.location.href = `${ url }`;
-			}
-			setIsLoading( false );
-		} catch ( { message } ) {
-			setIsLoading( false );
-			setSqlNotice( message );
-		}
-	};
-
 	return (
 		<>
-			{ parsedSQL.tableRows.length < 1 ? (
-				<Button variant="primary" onClick={ handleUpload }>
+			{ ( parsedSQL?.tableRows?.length || 0 ) < 1 ? (
+				<Button
+					data-testid="upload"
+					variant="primary"
+					onClick={ handleUpload }
+				>
 					{ __( 'Upload SQL File', 'sql-to-cpt' ) }
 				</Button>
 			) : (
-				<Button variant="primary" onClick={ handleImport }>
+				<Button
+					data-testid="convert"
+					variant="primary"
+					onClick={ handleImport }
+				>
 					{ __( 'Convert to CPT', 'sql-to-cpt' ) }
 				</Button>
 			) }

--- a/src/components/Notice.tsx
+++ b/src/components/Notice.tsx
@@ -1,9 +1,5 @@
 import { useSelect } from '@wordpress/data';
 
-interface NoticeProps {
-	message: string;
-}
-
 /**
  * Notice Component.
  *

--- a/src/components/Notice.tsx
+++ b/src/components/Notice.tsx
@@ -1,3 +1,5 @@
+import { useSelect } from '@wordpress/data';
+
 interface NoticeProps {
 	message: string;
 }
@@ -10,13 +12,18 @@ interface NoticeProps {
  *
  * @since 1.0.0
  *
- * @param {Object}      props         - The component props.
- * @param {NoticeProps} props.message - Message to be displayed in notice.
- *
  * @return {JSX.Element} The Notice component.
  */
-const Notice = ( { message }: NoticeProps ): JSX.Element => {
-	return message && <nav>{ message }</nav>;
+const Notice = (): JSX.Element => {
+	const { sqlNotice } = useSelect( ( select ) => {
+		const store: any = select( 'sql-to-cpt' );
+
+		return {
+			sqlNotice: store.getSqlNotice(),
+		};
+	}, [] );
+
+	return sqlNotice && <nav>{ sqlNotice }</nav>;
 };
 
 export default Notice;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from '@wordpress/element';
-
+import { useSelect } from '@wordpress/data';
 interface ProgressBarProps {
 	isLoading: boolean;
 }
@@ -13,13 +13,17 @@ interface ProgressBarProps {
  * @since 1.2.0
  * @since 1.3.0 Implement Interval logic.
  *
- * @param {Object}           props           - The component props.
- * @param {ProgressBarProps} props.isLoading - True|False.
- *
  * @return {JSX.Element} The Progress Bar component.
  */
-const ProgressBar = ( { isLoading }: ProgressBarProps ): JSX.Element => {
+const ProgressBar = (): JSX.Element => {
 	const [ progress, setProgress ] = useState< number >( 0 );
+	const { isLoading } = useSelect( ( select ) => {
+		const store: any = select( 'sql-to-cpt' );
+
+		return {
+			isLoading: store.isLoading(),
+		};
+	}, [] );
 
 	useEffect( () => {
 		let progressInterval: string | number | NodeJS.Timeout;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,8 +1,5 @@
 import { useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-interface ProgressBarProps {
-	isLoading: boolean;
-}
 
 /**
  * Progress Bar Component.
@@ -44,7 +41,11 @@ const ProgressBar = (): JSX.Element => {
 	return (
 		<>
 			{ isLoading && (
-				<div className="sqlt-cpt-progress-bar" role="progressbar">
+				<div
+					data-testid="progress-bar"
+					className="sqlt-cpt-progress-bar"
+					role="progressbar"
+				>
 					<div>
 						<div style={ { width: `${ progress }%` } } />
 					</div>

--- a/src/components/Purge.tsx
+++ b/src/components/Purge.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 interface PurgeProps {
@@ -16,16 +17,19 @@ interface PurgeProps {
  *
  * @since 1.3.0
  *
- * @param {Object}   props              - The component props.
- * @param {Function} props.setIsLoading - Function to set the loading state.
- * @param {Function} props.setSqlNotice - Function to set an SQL notice.
- *
  * @return {JSX.Element} The Purge component.
  */
-const Purge = ( { setIsLoading, setSqlNotice }: PurgeProps ): JSX.Element => {
+const Purge = (): JSX.Element => {
 	const [ postType, setPostType ] = useState( '' );
+	const { setIsLoading, setSqlNotice } = useDispatch( 'sql-to-cpt' );
 
-	const handlePurge = async () => {
+	/**
+	 * Purge all records saved
+	 * for a specific imported post type.
+	 *
+	 * @return {Promise<void>}
+	 */
+	const handlePurge = async (): Promise< void > => {
 		setIsLoading( true );
 
 		try {

--- a/src/components/Purge.tsx
+++ b/src/components/Purge.tsx
@@ -4,11 +4,6 @@ import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
-interface PurgeProps {
-	setIsLoading: Function;
-	setSqlNotice: Function;
-}
-
 /**
  * Purge Component.
  *

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -3,14 +3,6 @@ import { useSelect } from '@wordpress/data';
 
 import Disabled from './Disabled';
 
-interface ParsedSQLProps {
-	parsedSQL: {
-		tableName: string;
-		tableRows: any[];
-		tableColumns: string[];
-	};
-}
-
 /**
  * Table Columns Component.
  *
@@ -32,7 +24,7 @@ const TableColumns = (): JSX.Element => {
 
 	return (
 		<>
-			{ parsedSQL.tableColumns.length > 0 && (
+			{ parsedSQL?.tableColumns?.length > 0 && (
 				<div className="sqlt-cpt-table-columns" role="list">
 					<h3>{ __( 'Columns', 'sql-to-cpt' ) }</h3>
 					{ parsedSQL.tableColumns.map(

--- a/src/components/TableColumns.tsx
+++ b/src/components/TableColumns.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 import Disabled from './Disabled';
 
@@ -18,12 +19,17 @@ interface ParsedSQLProps {
  *
  * @since 1.2.0
  *
- * @param {Object}         props           - The component props.
- * @param {ParsedSQLProps} props.parsedSQL - The parsed SQL object.
- *
  * @return {JSX.Element} The Table Columns component.
  */
-const TableColumns = ( { parsedSQL }: ParsedSQLProps ): JSX.Element => {
+const TableColumns = (): JSX.Element => {
+	const { parsedSQL } = useSelect( ( select ) => {
+		const store: any = select( 'sql-to-cpt' );
+
+		return {
+			parsedSQL: store.getParsedSQL(),
+		};
+	}, [] );
+
 	return (
 		<>
 			{ parsedSQL.tableColumns.length > 0 && (

--- a/src/components/TableName.tsx
+++ b/src/components/TableName.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 import Disabled from './Disabled';
 
@@ -18,12 +19,17 @@ interface ParsedSQLProps {
  *
  * @since 1.2.0
  *
- * @param {Object}         props           - The component props.
- * @param {ParsedSQLProps} props.parsedSQL - The parsed SQL object.
- *
  * @return {JSX.Element} The Table Name component.
  */
-const TableName = ( { parsedSQL }: ParsedSQLProps ): JSX.Element => {
+const TableName = (): JSX.Element => {
+	const { parsedSQL } = useSelect( ( select ) => {
+		const store: any = select( 'sql-to-cpt' );
+
+		return {
+			parsedSQL: store.getParsedSQL(),
+		};
+	}, [] );
+
 	return (
 		<>
 			{ parsedSQL.tableName && (

--- a/src/components/TableName.tsx
+++ b/src/components/TableName.tsx
@@ -3,14 +3,6 @@ import { useSelect } from '@wordpress/data';
 
 import Disabled from './Disabled';
 
-interface ParsedSQLProps {
-	parsedSQL: {
-		tableName: string;
-		tableRows: any[];
-		tableColumns: string[];
-	};
-}
-
 /**
  * Table Name Component.
  *
@@ -32,10 +24,10 @@ const TableName = (): JSX.Element => {
 
 	return (
 		<>
-			{ parsedSQL.tableName && (
+			{ parsedSQL?.tableName && (
 				<div className="sqlt-cpt-table-name" role="list">
 					<h3>{ __( 'Table', 'sql-to-cpt' ) }</h3>
-					<Disabled name={ parsedSQL.tableName } />
+					<Disabled name={ parsedSQL?.tableName || '' } />
 				</div>
 			) }
 		</>

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,0 +1,24 @@
+import type { SQLState } from './types';
+
+export const actions = {
+	setIsLoading( value: boolean ) {
+		return {
+			type: 'SET_LOADING',
+			value,
+		};
+	},
+
+	setSqlNotice( value: string ) {
+		return {
+			type: 'SET_NOTICE',
+			value,
+		};
+	},
+
+	setParsedSQL( value: SQLState[ 'parsedSQL' ] ) {
+		return {
+			type: 'SET_PARSED_SQL',
+			value,
+		};
+	},
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,82 @@
+import { createReduxStore, register } from '@wordpress/data';
+
+export interface SQLState {
+	isLoading: boolean;
+	sqlNotice: string;
+	parsedSQL: {
+		tableName: string;
+		tableColumns: string[];
+		tableRows: any[];
+	};
+}
+
+const DEFAULT_STATE: SQLState = {
+	isLoading: false,
+	sqlNotice: '',
+	parsedSQL: {
+		tableName: '',
+		tableColumns: [],
+		tableRows: [],
+	},
+};
+
+const reducer = ( state: SQLState = DEFAULT_STATE, action: any ): SQLState => {
+	switch ( action.type ) {
+		case 'SET_LOADING':
+			return { ...state, isLoading: action.value };
+
+		case 'SET_NOTICE':
+			return { ...state, sqlNotice: action.value };
+
+		case 'SET_PARSED_SQL':
+			return { ...state, parsedSQL: action.value };
+
+		default:
+			return state;
+	}
+};
+
+const actions = {
+	setIsLoading( value: boolean ) {
+		return {
+			type: 'SET_LOADING',
+			value,
+		};
+	},
+
+	setSqlNotice( value: string ) {
+		return {
+			type: 'SET_NOTICE',
+			value,
+		};
+	},
+
+	setParsedSQL( value: SQLState[ 'parsedSQL' ] ) {
+		return {
+			type: 'SET_PARSED_SQL',
+			value,
+		};
+	},
+};
+
+const selectors = {
+	isLoading( state: SQLState ) {
+		return state.isLoading;
+	},
+
+	getSqlNotice( state: SQLState ) {
+		return state.sqlNotice;
+	},
+
+	getParsedSQL( state: SQLState ) {
+		return state.parsedSQL;
+	},
+};
+
+export const store = createReduxStore( 'sql-to-cpt', {
+	reducer,
+	actions,
+	selectors,
+} );
+
+register( store );

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,77 +1,8 @@
 import { createReduxStore, register } from '@wordpress/data';
 
-export interface SQLState {
-	isLoading: boolean;
-	sqlNotice: string;
-	parsedSQL: {
-		tableName: string;
-		tableColumns: string[];
-		tableRows: any[];
-	};
-}
-
-const DEFAULT_STATE: SQLState = {
-	isLoading: false,
-	sqlNotice: '',
-	parsedSQL: {
-		tableName: '',
-		tableColumns: [],
-		tableRows: [],
-	},
-};
-
-const reducer = ( state: SQLState = DEFAULT_STATE, action: any ): SQLState => {
-	switch ( action.type ) {
-		case 'SET_LOADING':
-			return { ...state, isLoading: action.value };
-
-		case 'SET_NOTICE':
-			return { ...state, sqlNotice: action.value };
-
-		case 'SET_PARSED_SQL':
-			return { ...state, parsedSQL: action.value };
-
-		default:
-			return state;
-	}
-};
-
-const actions = {
-	setIsLoading( value: boolean ) {
-		return {
-			type: 'SET_LOADING',
-			value,
-		};
-	},
-
-	setSqlNotice( value: string ) {
-		return {
-			type: 'SET_NOTICE',
-			value,
-		};
-	},
-
-	setParsedSQL( value: SQLState[ 'parsedSQL' ] ) {
-		return {
-			type: 'SET_PARSED_SQL',
-			value,
-		};
-	},
-};
-
-const selectors = {
-	isLoading( state: SQLState ) {
-		return state.isLoading;
-	},
-
-	getSqlNotice( state: SQLState ) {
-		return state.sqlNotice;
-	},
-
-	getParsedSQL( state: SQLState ) {
-		return state.parsedSQL;
-	},
-};
+import { reducer } from './reducer';
+import { actions } from './actions';
+import { selectors } from './selectors';
 
 export const store = createReduxStore( 'sql-to-cpt', {
 	reducer,

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -1,0 +1,21 @@
+import type { SQLState } from './types';
+import { DEFAULT_STATE } from './types';
+
+export const reducer = (
+	state: SQLState = DEFAULT_STATE,
+	action: any
+): SQLState => {
+	switch ( action.type ) {
+		case 'SET_LOADING':
+			return { ...state, isLoading: action.value };
+
+		case 'SET_NOTICE':
+			return { ...state, sqlNotice: action.value };
+
+		case 'SET_PARSED_SQL':
+			return { ...state, parsedSQL: action.value };
+
+		default:
+			return state;
+	}
+};

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,0 +1,15 @@
+import type { SQLState } from './types';
+
+export const selectors = {
+	isLoading( state: SQLState ) {
+		return state.isLoading;
+	},
+
+	getSqlNotice( state: SQLState ) {
+		return state.sqlNotice;
+	},
+
+	getParsedSQL( state: SQLState ) {
+		return state.parsedSQL;
+	},
+};

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,0 +1,19 @@
+export interface SQLState {
+	isLoading: boolean;
+	sqlNotice: string;
+	parsedSQL: {
+		tableName: string;
+		tableColumns: string[];
+		tableRows: any[];
+	};
+}
+
+export const DEFAULT_STATE: SQLState = {
+	isLoading: false,
+	sqlNotice: '',
+	parsedSQL: {
+		tableName: '',
+		tableColumns: [],
+		tableRows: [],
+	},
+};

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,4 +1,7 @@
 import { __ } from '@wordpress/i18n';
+import { select, dispatch } from '@wordpress/data';
+import type { MediaFrame } from '@wordpress/media-utils';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Get Root.
@@ -52,4 +55,99 @@ export const getModalParams = () => {
 		},
 		multiple: false,
 	};
+};
+
+/**
+ * Handle Upload.
+ *
+ * This function is responsible for opening the
+ * WP media modal to enable user select.
+ *
+ * @since 1.0.0
+ *
+ * @return {void}
+ */
+export const handleUpload = (): void => {
+	const wpMediaModal = wp.media( getModalParams() );
+	wpMediaModal.on( 'select', () => handleSelect( wpMediaModal ) ).open();
+};
+
+/**
+ * Handle Selection.
+ *
+ * This function is responsible for handling a
+ * selection made by the user.
+ *
+ * @since 1.0.0
+ *
+ * @param {MediaFrame} wpMediaModal WP Media Modal.
+ * @return Promise<void>
+ */
+export const handleSelect = async (
+	wpMediaModal: MediaFrame
+): Promise< void > => {
+	const args = wpMediaModal.state().get( 'selection' ).first().toJSON();
+	const { setSqlNotice, setParsedSQL, setIsLoading } = dispatch(
+		'sql-to-cpt'
+	) as any;
+
+	// Reset.
+	setSqlNotice( '' );
+	setParsedSQL( {
+		tableName: '',
+		tableColumns: [],
+		tableRows: [],
+	} );
+	setIsLoading( true );
+
+	// Parse SQL.
+	try {
+		setParsedSQL(
+			await apiFetch( {
+				path: '/sql-to-cpt/v1/parse',
+				method: 'POST',
+				data: {
+					...args,
+				},
+			} )
+		);
+		setIsLoading( false );
+	} catch ( { message } ) {
+		setIsLoading( false );
+		setSqlNotice( message );
+	}
+};
+
+/**
+ * Handle Import.
+ *
+ * This function is responsible for handling the
+ * import made by the user.
+ *
+ * @since 1.1.0
+ *
+ * @return Promise<void>
+ */
+export const handleImport = async (): Promise< void > => {
+	const { getParsedSQL } = select( 'sql-to-cpt' ) as any;
+	const { setSqlNotice, setIsLoading } = dispatch( 'sql-to-cpt' ) as any;
+	setIsLoading( true );
+
+	// Import SQL.
+	try {
+		const url = await apiFetch( {
+			path: '/sql-to-cpt/v1/import',
+			method: 'POST',
+			data: {
+				...getParsedSQL(),
+			},
+		} );
+		if ( url ) {
+			window.location.href = `${ url }`;
+		}
+		setIsLoading( false );
+	} catch ( { message } ) {
+		setIsLoading( false );
+		setSqlNotice( message );
+	}
 };

--- a/tests/js/ImportButton.test.tsx
+++ b/tests/js/ImportButton.test.tsx
@@ -1,83 +1,108 @@
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { ImportButton } from '../../src/components/All';
+import { handleUpload, handleImport } from '../../src/utils';
 
-import ImportButton from '../../src/components/ImportButton';
+import { useSelect } from '@wordpress/data';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
 
 jest.mock( '@wordpress/i18n', () => ( {
-	__: jest.fn( ( arg ) => arg ),
+	__: ( text: string ) => text,
 } ) );
 
-jest.mock( '@wordpress/components', () => ( {
-	Button: jest.fn( ( { children, variant, onClick } ) => {
-		return (
-			<>
-				<button className={ variant } onClick={ onClick }>
-					{ children }
-				</button>
-			</>
-		);
-	} ),
+jest.mock( '../../src/utils', () => ( {
+	handleUpload: jest.fn(),
+	handleImport: jest.fn(),
 } ) );
 
-const setIsLoading = jest.fn();
-const setSqlNotice = jest.fn();
-const setParsedSQL = jest.fn();
+const mockUseSelect = useSelect as jest.Mock;
 
-describe( 'ImportButton', () => {
-	it( 'renders the button with "Upload SQL File" text', () => {
-		const parsedSQL = {
-			tableName: 'student',
-			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-			tableRows: [],
-		};
-
-		const { container } = render(
-			<ImportButton
-				parsedSQL={ parsedSQL }
-				setIsLoading={ setIsLoading }
-				setSqlNotice={ setSqlNotice }
-				setParsedSQL={ setParsedSQL }
-			/>
-		);
-
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe(
-			`<button class="primary">Upload SQL File</button>`
-		);
-
-		// Assert the button is displayed.
-		const uploadButton = screen.getByRole( 'button' );
-		expect( uploadButton ).toHaveClass( 'primary' );
-		expect( uploadButton ).toBeInTheDocument();
-		expect( uploadButton ).toBeInstanceOf( HTMLButtonElement );
+describe( 'ImportButton component', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
-	it( 'renders the button with "Convert to CPT" text', () => {
-		const parsedSQL = {
-			tableName: 'student',
-			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
-		};
+	it( 'renders the Upload SQL File button', () => {
+		mockUseSelect.mockReturnValue( {
+			parsedSQL: {},
+		} );
 
-		const { container } = render(
-			<ImportButton
-				parsedSQL={ parsedSQL }
-				setIsLoading={ setIsLoading }
-				setSqlNotice={ setSqlNotice }
-				setParsedSQL={ setParsedSQL }
-			/>
-		);
+		render( <ImportButton /> );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe(
-			`<button class="primary">Convert to CPT</button>`
-		);
+		(
+			expect(
+				screen.getByRole( 'button', { name: 'Upload SQL File' } )
+			) as any
+		 ).toBeVisible();
+		(
+			expect(
+				screen.queryByRole( 'button', { name: 'Convert to CPT' } )
+			) as any
+		 ).not.toBeInTheDocument();
+	} );
 
-		// Assert the button is displayed.
-		const importButton = screen.getByRole( 'button' );
-		expect( importButton ).toHaveClass( 'primary' );
-		expect( importButton ).toBeInTheDocument();
-		expect( importButton ).toBeInstanceOf( HTMLButtonElement );
+	it( 'calls handleUpload when the Upload button is clicked', () => {
+		mockUseSelect.mockReturnValue( {
+			parsedSQL: {},
+		} );
+
+		render( <ImportButton /> );
+
+		const uploadButton = screen.getByRole( 'button', {
+			name: 'Upload SQL File',
+		} );
+
+		( expect( uploadButton ) as any ).toBeVisible();
+
+		fireEvent.click( uploadButton );
+
+		expect( handleUpload ).toHaveBeenCalled();
+	} );
+
+	it( 'renders the Convert to CPT button', () => {
+		mockUseSelect.mockReturnValue( {
+			parsedSQL: {
+				tableName: 'student',
+				tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+				tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+			},
+		} );
+
+		render( <ImportButton /> );
+
+		(
+			expect(
+				screen.getByRole( 'button', { name: 'Convert to CPT' } )
+			) as any
+		 ).toBeVisible();
+		(
+			expect(
+				screen.queryByRole( 'button', { name: 'Upload SQL File' } )
+			) as any
+		 ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls handleImport when the Convert button is clicked', () => {
+		mockUseSelect.mockReturnValue( {
+			parsedSQL: {
+				tableName: 'student',
+				tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+				tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+			},
+		} );
+
+		render( <ImportButton /> );
+
+		const convertButton = screen.getByRole( 'button', {
+			name: 'Convert to CPT',
+		} );
+
+		( expect( convertButton ) as any ).toBeVisible();
+
+		fireEvent.click( convertButton );
+
+		expect( handleImport ).toHaveBeenCalled();
 	} );
 } );

--- a/tests/js/Notice.test.tsx
+++ b/tests/js/Notice.test.tsx
@@ -1,34 +1,50 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { Notice } from '../../src/components/All';
 
-import Notice from '../../src/components/Notice';
+import { useSelect } from '@wordpress/data';
 
-describe( 'Notice', () => {
-	it( 'renders the component with correct text', () => {
-		const { container } = render(
-			<Notice message="Fatal Error! Wrong file type: sample-1.png" />
-		);
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe(
-			`<nav>Fatal Error! Wrong file type: sample-1.png</nav>`
-		);
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
 
-		// Assert the text content is rendered inside the nav element.
-		const nav = screen.getByText(
-			'Fatal Error! Wrong file type: sample-1.png'
-		);
-		const navName = nav.tagName.toLowerCase();
-		expect( navName ).toBe( 'nav' );
-		expect( nav ).toBeInTheDocument();
-		expect( nav ).toBeInstanceOf( HTMLElement );
+const mockUseSelect = useSelect as jest.Mock;
+
+describe( 'Notice component', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
-	it( 'DOES NOT render the Notice', () => {
-		const { container } = render( <Notice message="" /> );
+	it( 'renders the failed notice if any from API response', () => {
+		mockUseSelect.mockReturnValue( {
+			sqlNotice: 'Fatal Error! Wrong file type: sample-1.png',
+		} );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe( `` );
+		render( <Notice /> );
+
+		(
+			expect(
+				screen.getByText( 'Fatal Error! Wrong file type: sample-1.png' )
+			) as any
+		 ).toBeVisible();
+	} );
+
+	it( 'does not render any notice if empty', () => {
+		mockUseSelect.mockReturnValue( {
+			sqlNotice: '',
+		} );
+
+		render( <Notice /> );
+
+		(
+			expect(
+				screen.queryByText(
+					'Fatal Error! Wrong file type: sample-1.png'
+				)
+			) as any
+		 ).not.toBeInTheDocument();
 	} );
 } );

--- a/tests/js/ProgressBar.test.tsx
+++ b/tests/js/ProgressBar.test.tsx
@@ -1,31 +1,42 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { ProgressBar } from '../../src/components/All';
 
-import ProgressBar from '../../src/components/ProgressBar';
+import { useSelect } from '@wordpress/data';
 
-describe( 'ProgressBar', () => {
-	it( 'renders the Progress Bar', () => {
-		const { container } = render( <ProgressBar isLoading={ true } /> );
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe(
-			`<div class="sqlt-cpt-progress-bar" role="progressbar"><div><div style="width: 0%;"></div></div><p>0%</p></div>`
-		);
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
 
-		// Assert the ProgressBar is rendered and is disabled.
-		const progressBar = screen.getByRole( 'progressbar' );
-		expect( progressBar ).toBeInTheDocument();
-		expect( progressBar ).toBeInstanceOf( HTMLDivElement );
-		expect( progressBar ).toContainHTML(
-			'<div><div style="width: 0%;"></div></div><p>0%</p>'
-		);
+const mockUseSelect = useSelect as jest.Mock;
+
+describe( 'ProgressBar component', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
-	it( 'DOES NOT render the Progress Bar', () => {
-		const { container } = render( <ProgressBar isLoading={ false } /> );
+	it( 'renders the Progress Bar', () => {
+		mockUseSelect.mockReturnValue( {
+			isLoading: true,
+		} );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe( `` );
+		render( <ProgressBar /> );
+
+		( expect( screen.getByTestId( 'progress-bar' ) ) as any ).toBeVisible();
+	} );
+
+	it( 'does not render table columns if empty', () => {
+		mockUseSelect.mockReturnValue( {
+			isLoading: false,
+		} );
+
+		render( <ProgressBar /> );
+
+		(
+			expect( screen.queryByTestId( 'progress-bar' ) ) as any
+		 ).not.toBeInTheDocument();
 	} );
 } );

--- a/tests/js/TableColumns.test.tsx
+++ b/tests/js/TableColumns.test.tsx
@@ -1,52 +1,87 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { TableColumns } from '../../src/components/All';
 
-import TableColumns from '../../src/components/TableColumns';
+import { useSelect } from '@wordpress/data';
 
-jest.mock( '@wordpress/i18n', () => ( {
-	__: jest.fn( ( arg ) => arg ),
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
 } ) );
 
-describe( 'TableColumns', () => {
-	it( 'renders the Table Columns', () => {
-		const parsedSQL = {
-			tableName: 'student',
-			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
-		};
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
 
-		const { container } = render(
-			<TableColumns parsedSQL={ parsedSQL } />
-		);
+jest.mock( '../../src/components/Disabled', () => ( {
+	__esModule: true,
+	default: ( { name }: { name: string } ) => (
+		<div data-testid={ name }>{ name }</div>
+	),
+} ) );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe(
-			`<div class="sqlt-cpt-table-columns" role="list"><h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p></div>`
-		);
+const mockUseSelect = useSelect as jest.Mock;
 
-		// Assert the Table Columns are displayed.
-		const tableColumns = screen.getByRole( 'list' );
-		expect( tableColumns ).toHaveClass( 'sqlt-cpt-table-columns' );
-		expect( tableColumns ).toBeInTheDocument();
-		expect( tableColumns ).toBeInstanceOf( HTMLDivElement );
-		expect( tableColumns ).toContainHTML(
-			'<h3>Columns</h3><p><input type="text" disabled="" value="id"></p><p><input type="text" disabled="" value="name"></p><p><input type="text" disabled="" value="age"></p><p><input type="text" disabled="" value="sex"></p><p><input type="text" disabled="" value="email_address"></p>'
-		);
+describe( 'TableColumns component', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
-	it( 'DOES NOT render the Table Columns', () => {
-		const parsedSQL = {
-			tableName: 'student',
-			tableColumns: [],
-			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
-		};
+	it( 'renders table columns', () => {
+		mockUseSelect.mockReturnValue( {
+			parsedSQL: {
+				tableName: 'student',
+				tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+				tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+			},
+		} );
 
-		const { container } = render(
-			<TableColumns parsedSQL={ parsedSQL } />
+		render( <TableColumns /> );
+
+		( expect( screen.getByText( 'Columns' ) ) as any ).toBeInTheDocument();
+		( expect( screen.getByTestId( 'id' ) ) as any ).toHaveTextContent(
+			'id'
 		);
+		( expect( screen.getByTestId( 'name' ) ) as any ).toHaveTextContent(
+			'name'
+		);
+		( expect( screen.getByTestId( 'age' ) ) as any ).toHaveTextContent(
+			'age'
+		);
+		( expect( screen.getByTestId( 'sex' ) ) as any ).toHaveTextContent(
+			'sex'
+		);
+		(
+			expect( screen.getByTestId( 'email_address' ) ) as any
+		 ).toHaveTextContent( 'email_address' );
+	} );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe( `` );
+	it( 'does not render table columns if empty', () => {
+		mockUseSelect.mockReturnValue( {
+			parsedSQL: {
+				tableName: 'student',
+				tableColumns: [],
+				tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+			},
+		} );
+
+		render( <TableColumns /> );
+
+		(
+			expect( screen.queryByText( 'Columns' ) ) as any
+		 ).not.toBeInTheDocument();
+		(
+			expect( screen.queryByTestId( 'id' ) ) as any
+		 ).not.toBeInTheDocument();
+		(
+			expect( screen.queryByTestId( 'name' ) ) as any
+		 ).not.toBeInTheDocument();
+		(
+			expect( screen.queryByTestId( 'age' ) ) as any
+		 ).not.toBeInTheDocument();
+		(
+			expect( screen.queryByTestId( 'sex' ) ) as any
+		 ).not.toBeInTheDocument();
+		(
+			expect( screen.queryByTestId( 'email_address' ) ) as any
+		 ).not.toBeInTheDocument();
 	} );
 } );

--- a/tests/js/TableName.test.tsx
+++ b/tests/js/TableName.test.tsx
@@ -1,45 +1,57 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { TableName } from '../../src/components/All';
 
-import TableName from '../../src/components/TableName';
+import { useSelect } from '@wordpress/data';
 
-jest.mock( '@wordpress/i18n', () => ( {
-	__: jest.fn( ( arg ) => arg ),
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
 } ) );
 
-describe( 'TableName', () => {
-	it( 'renders the Table Name and its input', () => {
-		const parsedSQL = {
-			tableName: 'student',
-			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
-		};
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
 
-		const { container } = render( <TableName parsedSQL={ parsedSQL } /> );
+jest.mock( '../../src/components/Disabled', () => ( {
+	__esModule: true,
+	default: ( { name }: { name: string } ) => (
+		<div data-testid="disabled">{ name }</div>
+	),
+} ) );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe(
-			`<div class="sqlt-cpt-table-name" role="list"><h3>Table</h3><p><input type="text" disabled="" value="student"></p></div>`
-		);
+const mockUseSelect = useSelect as jest.Mock;
 
-		// Assert the Table Name is displayed.
-		const tableName = screen.getByRole( 'list' );
-		expect( tableName ).toHaveClass( 'sqlt-cpt-table-name' );
-		expect( tableName ).toBeInTheDocument();
-		expect( tableName ).toBeInstanceOf( HTMLDivElement );
+describe( 'TableName component', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
-	it( 'DOES NOT render the Table Name', () => {
-		const parsedSQL = {
-			tableName: '',
-			tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
-			tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
-		};
+	it( 'renders table name when available', () => {
+		mockUseSelect.mockReturnValue( {
+			parsedSQL: {
+				tableName: 'student',
+				tableColumns: [ 'id', 'name', 'age', 'sex', 'email_address' ],
+				tableRows: [ [ 1, 'John Doe', 37, 'M', 'john@doe.com' ] ],
+			},
+		} );
 
-		const { container } = render( <TableName parsedSQL={ parsedSQL } /> );
+		render( <TableName /> );
 
-		// Expect Component to look like so:
-		expect( container.innerHTML ).toBe( `` );
+		( expect( screen.getByText( 'Table' ) ) as any ).toBeInTheDocument();
+		( expect( screen.getByTestId( 'disabled' ) ) as any ).toHaveTextContent(
+			'student'
+		);
+	} );
+
+	it( 'does not render when tableName is empty', () => {
+		mockUseSelect.mockReturnValue( { parsedSQL: {} } );
+
+		render( <TableName /> );
+
+		(
+			expect( screen.queryByText( 'Table' ) ) as any
+		 ).not.toBeInTheDocument();
+		(
+			expect( screen.queryByTestId( 'disabled' ) ) as any
+		 ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
This PR resolves [WP-42](https://appworld.atlassian.net/browse/WP-42)

## Description / Background Context

This PR refactors the way we are using setter methods to instead use a custom WP store that prevents us manually passing props via prop drilling.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn build`.
- Proceed to the plugin page.
- Upload a `.sql` file and convert to CPT.
- Observe that there are no regressions introduced and plugin works correctly as before.

## Screenshots / Screencast

<img width="1444" height="755" alt="Screenshot 2026-04-10 at 19 50 23" src="https://github.com/user-attachments/assets/3ad5646a-da78-4cd1-91a4-0837a419f3cb" />