### PR TITLE
Chore: Pull request template added

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,16 @@
+This PR resolves #1. <!-- What issue does this PR resolve? -->
+
+## Description / Background Context
+
+<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
+
+## Testing Instructions
+
+<!-- Please include step by step instructions on how to test this PR. -->
+<!-- 1. Pull PR to local. -->
+<!-- 2. Run `yarn build` to build correctly. -->
+<!-- 3. etc. -->
+
+## Screenshots / Screencast
+
+<!-- If you would like to upload screenshots, feel free to show the difference between before and after the change. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
 ## 1.4.0
-* Chore: Pull Request template added.
 * Feat: Setup custom WP store to prevent props drilling across components.
 * Refactor: Replaced hard coded HTTP verbs with `WP_REST_Server` constant.
 * Refactor: Simplified register mimes.
 * Refactor: Used webpack generated dependencies.
 * Refactor: Replaced fully qualified path classes with their `use` counter part
 * Refactor: Replaced `get-400-response` with `get-error-response` and sets `400` as the default status.
+* Chore: Pull Request template added.
 
 ## 1.3.4
 * Specify `wordpress-plugin` as Composer package type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.4.0
+* Chore: Pull Request template added.
 * Refactor: Replaced hard coded HTTP verbs with `WP_REST_Server` constant.
 * Refactor: Simplified register mimes.
 * Refactor: Used webpack generated dependencies.

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 == Changelog ==
 
 = 1.4.0
+* Chore: Pull Request template added.
 * Refactor: Replaced hard coded HTTP verbs with `WP_REST_Server` constant.
 * Refactor: Simplified register mimes.
 * Refactor: Used webpack generated dependencies.

--- a/readme.txt
+++ b/readme.txt
@@ -70,13 +70,13 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 == Changelog ==
 
 = 1.4.0
-* Chore: Pull Request template added.
 * Feat: Setup custom WP store to prevent props drilling across components.
 * Refactor: Replaced hard coded HTTP verbs with `WP_REST_Server` constant.
 * Refactor: Simplified register mimes.
 * Refactor: Used webpack generated dependencies.
 * Refactor: Replaced fully qualified path classes with their `use` counter part
 * Refactor: Replaced `get-400-response` with `get-error-`response` and sets 400 as the default status.
+* Chore: Pull Request template added.
 
 = 1.3.4
 * Specify `wordpress-plugin` as Composer package type.


### PR DESCRIPTION
This PR resolves [WP-52](https://appworld.atlassian.net/browse/WP-52).

## Description / Background Context

This PR simply introduces a template that enables all contributors use the same template for raising PRs.

## Testing Instructions

- Pull PR to local.
- Observe that `pull_request_template.md` is now part of the `.github` folder.
- Check out to a new branch from this branch.
- Attempt to raise a new PR.
- Observe that you can now see the template in action.