### PR TITLE
Refactor: Use get-error-response in place of get-400-response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Refactor: Simplified register mimes.
 * Refactor: Used webpack generated dependencies.
 * Refactor: Replaced fully qualified path classes with their `use` counter part
+* Refactor: Replaced `get-400-response` with `get-error-response` and sets `400` as the default status.
 
 ## 1.3.4
 * Specify `wordpress-plugin` as Composer package type.

--- a/inc/Abstracts/Route.php
+++ b/inc/Abstracts/Route.php
@@ -95,27 +95,27 @@ abstract class Route implements Router {
 	}
 
 	/**
-	 * Get 400 Response.
+	 * Get Error Response.
 	 *
-	 * This method returns a 400 response for Bad
+	 * This method returns an error response for Bad
 	 * requests submitted.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $message Error Msg.
+	 * @param int  $code  Error Status code.
 	 * @return \WP_Error
 	 */
-	public function get_400_response( $message ): WP_Error {
+	public function get_error_response( $message, $code = 400 ): WP_Error {
 		$args = $this->request->get_json_params();
 
 		return new WP_Error(
 			'sql-to-cpt-bad-request',
 			sprintf(
-				'Fatal Error: Bad Request, %s',
+				'Fatal Error: %s',
 				$message
 			),
 			[
-				'status'  => 400,
+				'status'  => $code,
 				'request' => $args,
 			]
 		);

--- a/inc/Routes/Import.php
+++ b/inc/Routes/Import.php
@@ -71,7 +71,7 @@ class Import extends Route implements Router {
 
 		// Bail out, if bad request.
 		if ( empty( $table_name ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					'Empty Table name: %s',
 					$table_name
@@ -81,7 +81,7 @@ class Import extends Route implements Router {
 
 		// Bail out, if bad request.
 		if ( empty( $table_columns ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					'Empty Table columns: %s',
 					wp_json_encode( $table_columns )
@@ -91,7 +91,7 @@ class Import extends Route implements Router {
 
 		// Bail out, if bad request.
 		if ( empty( $table_rows ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					'Empty Table rows: %s',
 					wp_json_encode( $table_rows )
@@ -102,7 +102,7 @@ class Import extends Route implements Router {
 		$response = $this->get_response();
 
 		if ( is_null( $response ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				__( 'Error: Failed SQL Import!', 'sql-to-cpt' )
 			);
 		}

--- a/inc/Routes/Parse.php
+++ b/inc/Routes/Parse.php
@@ -79,7 +79,7 @@ class Parse extends Route implements Router {
 
 		// Bail out, if it does NOT exists.
 		if ( ! file_exists( $this->file ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					'File does not exists for ID: %s',
 					$this->args['id'] ?? ''
@@ -89,7 +89,7 @@ class Parse extends Route implements Router {
 
 		// Bail out, if it is not SQL.
 		if ( ! $this->is_sql( $this->file ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					'Wrong file type has been received: %s',
 					$this->args['filename'] ?? ''
@@ -117,7 +117,7 @@ class Parse extends Route implements Router {
 		try {
 			$response = $parser->get_parsed_sql( $this->file );
 		} catch ( Exception $e ) {
-			$response = $this->get_400_response(
+			$response = $this->get_error_response(
 				sprintf( 'Unable to parse SQL file: %s', $e->getMessage() )
 			);
 			error_log( $response );

--- a/inc/Routes/Purge.php
+++ b/inc/Routes/Purge.php
@@ -78,7 +78,7 @@ class Purge extends Route implements Router {
 
 		// Bail out, if bad request.
 		if ( empty( $this->post_type ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					__( 'Please select a custom post type to delete.', 'sql-to-cpt' )
 				)
@@ -88,7 +88,7 @@ class Purge extends Route implements Router {
 		$undeleted_posts = $this->get_response();
 
 		if ( ! empty( $undeleted_posts ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					'Unable to delete all Posts for CPT: %s',
 					$this->post_type

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Refactor: Simplified register mimes.
 * Refactor: Used webpack generated dependencies.
 * Refactor: Replaced fully qualified path classes with their `use` counter part
+* Refactor: Replaced `get-400-response` with `get-error-`response` and sets 400 as the default status.
 
 = 1.3.4
 * Specify `wordpress-plugin` as Composer package type.

--- a/tests/php/Abstracts/RouteTest.php
+++ b/tests/php/Abstracts/RouteTest.php
@@ -12,7 +12,7 @@ use SqlToCpt\Abstracts\Route;
 /**
  * @covers \SqlToCpt\Abstracts\Route::request
  * @covers \SqlToCpt\Abstracts\Route::register_route
- * @covers \SqlToCpt\Abstracts\Route::get_400_response
+ * @covers \SqlToCpt\Abstracts\Route::get_error_response
  * @covers \SqlToCpt\Abstracts\Route::is_user_permissible
  */
 class RouteTest extends TestCase {
@@ -53,7 +53,7 @@ class RouteTest extends TestCase {
 		$this->assertConditionsMet();
 	}
 
-	public function test_get_400_response() {
+	public function test_get_error_response() {
 		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
 		$request->shouldAllowMockingProtectedMethods();
 
@@ -81,7 +81,7 @@ class RouteTest extends TestCase {
 				]
 			);
 
-		$error_response = $this->route->get_400_response( 'Something went terribly wrong...' );
+		$error_response = $this->route->get_error_response( 'Something went terribly wrong...' );
 
 		$this->assertInstanceOf( WP_Error::class, $error_response );
 		$this->assertConditionsMet();

--- a/tests/php/Routes/ImportTest.php
+++ b/tests/php/Routes/ImportTest.php
@@ -14,7 +14,7 @@ use SqlToCpt\Routes\Import;
  * @covers \SqlToCpt\Routes\Import::response
  * @covers \SqlToCpt\Routes\Import::get_response
  * @covers \SqlToCpt\Routes\Import::get_post_type
- * @covers \SqlToCpt\Abstracts\Route::get_400_response
+ * @covers \SqlToCpt\Abstracts\Route::get_error_response
  */
 class ImportTest extends TestCase {
 	public Import $import;

--- a/tests/php/Routes/ParseTest.php
+++ b/tests/php/Routes/ParseTest.php
@@ -16,7 +16,7 @@ use SqlToCpt\Routes\Parse;
  * @covers \SqlToCpt\Routes\Parse::is_sql
  * @covers \SqlToCpt\Routes\Parse::response
  * @covers \SqlToCpt\Routes\Parse::get_response
- * @covers \SqlToCpt\Abstracts\Route::get_400_response
+ * @covers \SqlToCpt\Abstracts\Route::get_error_response
  * @covers \SqlToCpt\Core\Parser::get_parsed_sql
  * @covers \SqlToCpt\Core\Parser::get_sql_string
  * @covers \SqlToCpt\Core\Parser::get_sql_table_name
@@ -178,7 +178,7 @@ class ParseTest extends TestCase {
 
 		$parse->file = '';
 
-		$parse->shouldReceive( 'get_400_response' )
+		$parse->shouldReceive( 'get_error_response' )
 			->andReturn( $wp_error );
 
 		$response = $parse->get_response( $parser );

--- a/tests/php/Routes/PurgeTest.php
+++ b/tests/php/Routes/PurgeTest.php
@@ -17,7 +17,7 @@ use SqlToCpt\Routes\Purge;
  * @covers \SqlToCpt\Routes\Purge::get_response
  * @covers \SqlToCpt\Routes\Purge::get_post_ids
  * @covers \SqlToCpt\Routes\Purge::get_updated_cpts
- * @covers \SqlToCpt\Abstracts\Route::get_400_response
+ * @covers \SqlToCpt\Abstracts\Route::get_error_response
  */
 class PurgeTest extends TestCase {
 	public Purge $purge;


### PR DESCRIPTION
This PR resolves [WP-48](https://appworld.atlassian.net/browse/WP-48).

## Description / Background Context

We are currently using the `get_400_response` method for server errors. It makes sense for us to refactor this to a more general purpose (agnostic) method so that we can throw any type of error that is not strictly related to a `400`.

This PR refactors this method to use to a default `400` status code.

## Testing Instructions

- Pull PR to local.
- Run tests using `composer run test`.
- Observe that all test cases pass correctly.
- Head over to the plugin page and upload a file which is not a `.sql` file.
- Observe that it correctly throws the error shown below:

---

<img width="1733" height="85" alt="Screenshot 2026-04-11 110704" src="https://github.com/user-attachments/assets/718db83a-4c08-42ab-a61b-a24704aae4da" />