### PR TITLE
Release 1.4.0 | Hotfix: Resolve build error in production

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,6 @@ jobs:
         run: |
           yarn install && yarn build
           git add dist/ -f
-          git rm dist/app.asset.php -f
-          git rm dist/app.js.map -f
           git rm package.json
 
       - name: Build Vendor folder


### PR DESCRIPTION
This PR resolves [WP-202](https://appworld.atlassian.net/browse/WP-202).

## Description / Background Context

At the moment, some important files are being removed in the workflow for the build stage. This is not supposed to be so. This PR resolves this issue.

## Testing Steps

- Pull PR to local.
- Run `yarn build` to build correctly.
- Open plugin options page.
- Observe that you now see the plugin page load correctly like so:

---

<img width="1043" height="598" alt="Screenshot 2026-04-23 at 17 11 02" src="https://github.com/user-attachments/assets/d8b949b5-7ccb-474e-95db-a2e42b4d4363" />