### PR TITLE
Feat: Add more plugins options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.0
+* Feat: Add `More Plugins` options page.
+
 ## 1.4.3
 * Tested up to WP 7.0.
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
 		}
 	],
 	"require": {
-    "badasswp/pluginate": "^1.0"
-  },
+		"badasswp/pluginate": "^1.0"
+	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.6",
 		"mockery/mockery": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
 			"email": "badasswpdev@gmail.com"
 		}
 	],
+	"require": {
+    "badasswp/pluginate": "^1.0"
+  },
 	"require-dev": {
 		"phpunit/phpunit": "^9.6",
 		"mockery/mockery": "^1.6",

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -13,7 +13,27 @@ namespace SqlToCpt\Services;
 use SqlToCpt\Abstracts\Service;
 use SqlToCpt\Interfaces\Kernel;
 
+use Pluginate\Admin as Pluginate;
+
 class Admin extends Service implements Kernel {
+	/**
+	 * Pluginate instance.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @var Pluginate
+	 */
+	public Pluginate $pluginate;
+
+	/**
+	 * Admin constructor.
+	 *
+	 * @since 1.5.0
+	 */
+	public function __construct() {
+		$this->pluginate = new Pluginate( 'sql-to-cpt' );
+	}
+
 	/**
 	 * Bind to WP.
 	 *
@@ -23,6 +43,7 @@ class Admin extends Service implements Kernel {
 	 */
 	public function register(): void {
 		add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
+		add_action( 'admin_init', [ $this->pluginate, 'init' ] );
 	}
 
 	/**
@@ -43,6 +64,15 @@ class Admin extends Service implements Kernel {
 			[ $this, 'register_admin_page' ],
 			'dashicons-database',
 			90
+		);
+
+		add_submenu_page(
+			'sql-to-cpt',
+			__( 'More Plugins', 'sql-to-cpt' ),
+			__( 'More Plugins', 'sql-to-cpt' ),
+			'manage_options',
+			sprintf( '%s-more-plugins', 'sql-to-cpt' ),
+			[ $this, 'register_more_plugins' ]
 		);
 	}
 
@@ -67,6 +97,35 @@ class Admin extends Service implements Kernel {
 				esc_html__( 'Import & Convert SQL files to Custom Post Types (CPT).', 'sql-to-cpt' ),
 				esc_html__( 'Loading...', 'sql-to-cpt' ),
 			]
+		);
+	}
+
+	/**
+	 * Register More Plugins.
+	 *
+	 * This controls the display of the
+	 * "More Plugins" submenu page.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return void
+	 */
+	public function register_more_plugins(): void {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		vprintf(
+			'<section class="wrap">
+				<h1>%s</h1>
+				<p>%s</p>
+				%s
+			</section>',
+			array_map(
+				'__',
+				[
+					'More Plugins',
+					'Check out some other amazing plugin of ours...',
+					$this->pluginate->get_more_plugins(),
+				]
+			)
 		);
 	}
 }

--- a/tests/unit/php/Core/ContainerTest.php
+++ b/tests/unit/php/Core/ContainerTest.php
@@ -23,6 +23,7 @@ use SqlToCpt\Abstracts\Service;
  * @covers \SqlToCpt\Services\Post::__construct
  * @covers \SqlToCpt\Core\Post::__construct
  * @covers \SqlToCpt\Services\Routes::__construct
+ * @covers \SqlToCpt\Services\Admin::__construct
  */
 class ContainerTest extends TestCase {
 	public Container $container;
@@ -105,6 +106,16 @@ class ContainerTest extends TestCase {
 			[
 				Service::$services[ Boot::class ],
 				'register_scripts',
+			]
+		);
+
+		$admin = Service::$services[ Admin::class ];
+
+		WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				$admin->pluginate,
+				'init',
 			]
 		);
 

--- a/tests/unit/php/Services/AdminTest.php
+++ b/tests/unit/php/Services/AdminTest.php
@@ -10,6 +10,7 @@ use SqlToCpt\Services\Admin;
  * @covers \SqlToCpt\Services\Admin::register
  * @covers \SqlToCpt\Services\Admin::register_admin_menu
  * @covers \SqlToCpt\Services\Admin::register_admin_page
+ * @covers \SqlToCpt\Services\Admin::__construct
  */
 class AdminTest extends TestCase {
 	public Admin $admin;
@@ -26,6 +27,7 @@ class AdminTest extends TestCase {
 
 	public function test_register() {
 		WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_admin_menu' ] );
+		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin->pluginate, 'init' ] );
 
 		$this->admin->register();
 
@@ -49,6 +51,21 @@ class AdminTest extends TestCase {
 				[ $this->admin, 'register_admin_page' ],
 				'dashicons-database',
 				90
+			)
+			->andReturn( null );
+
+		WP_Mock::userFunction( '__' )
+			->andReturnUsing( fn( $text, $domain ) => $text );
+
+		WP_Mock::userFunction( 'add_submenu_page' )
+			->once()
+			->with(
+				'sql-to-cpt',
+				'More Plugins',
+				'More Plugins',
+				'manage_options',
+				'sql-to-cpt-more-plugins',
+				[ $this->admin, 'register_more_plugins' ]
 			)
 			->andReturn( null );
 


### PR DESCRIPTION
This PR resolves [WP-192](https://appworld.atlassian.net/browse/WP-192)

## Description / Background Context

This PR introduces a new More Plugins options page via the Pluginate repo.

## Testing Instructions

- Pull PR to local.
- Run `composer update` to pull in the `Pluginate` package.
- Proceed to the **More Plugins** page under the **SQL to CPT** menu.
- Observe that everything still works correctly as expected and you can install and activate a plugin from same.

## Screenshots / Screencast

<img width="952" height="418" alt="Screenshot 2026-06-10 083835" src="https://github.com/user-attachments/assets/012928b8-fcbe-4454-8a4b-8e4c8d1549c4" />

